### PR TITLE
fix (data in BasicTokenSender.sol)

### DIFF
--- a/contracts/BasicTokenSender.sol
+++ b/contracts/BasicTokenSender.sol
@@ -69,7 +69,7 @@ contract BasicTokenSender is Withdraw {
 
         Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
             receiver: abi.encode(receiver),
-            data: "",
+            data: abi.encode(""),
             tokenAmounts: tokensToSendDetails,
             extraArgs: "",
             feeToken: payFeesIn == PayFeesIn.LINK ? i_link : address(0)


### PR DESCRIPTION
In Example 3, data must be modified in the BasicTokenSender.sol code 

When receiving a message in the BasicMessageReceiver.sol code, it receives data of the message as latestMessage = abi.decode(message.data, (string)). Therefore, in BasicTokenSender.sol, an empty string must be **abi.encode("")** and included in the message.


