### PR TITLE
Refactors hardhat tasks code, makes it compact & increases code readability

### DIFF
--- a/tasks/ccip-token-transfer-batch.ts
+++ b/tasks/ccip-token-transfer-batch.ts
@@ -2,8 +2,7 @@
 
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig, getPayFeesIn } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getRouterConfig, getPayFeesIn, getSignerAndProvider } from "./utils";
 import { IRouterClient, IRouterClient__factory, IERC20, IERC20__factory } from "../typechain-types";
 import { TokenAmounts } from "./constants";
 import { BasicTokenSender } from "../typechain-types/artifacts/contracts/BasicTokenSender";
@@ -23,12 +22,7 @@ task(`ccip-token-transfer-batch`, `Transfers tokens from one blockchain to anoth
         const { sourceBlockchain, basicTokenSenderAddress, destinationBlockchain, receiver, tokenAmounts, payFeesIn } = taskArguments;
         const tokensToSendDetails: TokenAmounts[] = JSON.parse(tokenAmounts);
 
-        const privateKey = getPrivateKey();
-        const sourceRpcProviderUrl = getProviderRpcUrl(sourceBlockchain);
-
-        const provider = new providers.JsonRpcProvider(sourceRpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(provider);
+        const { signer, provider } = getSignerAndProvider(sourceBlockchain);
 
         const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(sourceBlockchain).address;
         const targetChainSelector = getRouterConfig(destinationBlockchain).chainSelector;

--- a/tasks/ccip-token-transfer.ts
+++ b/tasks/ccip-token-transfer.ts
@@ -1,7 +1,7 @@
 import { task } from "hardhat/config";
-import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers, utils, constants } from "ethers";
+import { TaskArguments } from "hardhat/types";
+import { getRouterConfig, getSignerAndProvider } from "./utils";
+import { utils, constants } from "ethers";
 import { IRouterClient, IRouterClient__factory, IERC20, IERC20__factory } from "../typechain-types";
 import { Spinner } from "../utils/spinner";
 import { getCcipMessageId } from "./helpers";
@@ -18,12 +18,7 @@ task(`ccip-token-transfer`, `Transfers tokens from one blockchain to another usi
     .setAction(async (taskArguments: TaskArguments) => {
         const { sourceBlockchain, destinationBlockchain, receiver, tokenAddress, amount, feeTokenAddress, gasLimit } = taskArguments;
 
-        const privateKey = getPrivateKey();
-        const sourceRpcProviderUrl = getProviderRpcUrl(sourceBlockchain);
-
-        const provider = new providers.JsonRpcProvider(sourceRpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(provider);
+        const { signer, provider } = getSignerAndProvider(sourceBlockchain);
 
         const spinner: Spinner = new Spinner();
 

--- a/tasks/ccip-token-transfer.ts
+++ b/tasks/ccip-token-transfer.ts
@@ -95,7 +95,7 @@ task(`ccip-token-transfer`, `Transfers tokens from one blockchain to another usi
 
             const feeToken: IERC20 = IERC20__factory.connect(feeTokenAddress, signer);
 
-            console.log(`ℹ️  Attempting to approve Router smart contract (${routerAddress}) to spend ${fees} of ${tokenAddress} tokens for Chainlink CCIP fees on behalf of ${signer.address}`);
+            console.log(`ℹ️  Attempting to approve Router smart contract (${routerAddress}) to spend ${fees} of ${feeTokenAddress} tokens for Chainlink CCIP fees on behalf of ${signer.address}`);
             spinner.start();
 
             const approvalTx = await feeToken.approve(routerAddress, fees);

--- a/tasks/deploy-basic-message-receiver.ts
+++ b/tasks/deploy-basic-message-receiver.ts
@@ -1,31 +1,25 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers } from "ethers";
-import { BasicMessageReceiver__factory, BasicMessageReceiver } from "../typechain-types";
+import { getRouterConfig, getSigner } from "./utils";
 import { Spinner } from "../utils/spinner";
 
 task(`deploy-basic-message-receiver`, `Deploys the BasicMessageReceiver smart contract`)
     .addOptionalParam(`router`, `The address of the Router contract`)
     .setAction(async (taskArguments: TaskArguments, hre: HardhatRuntimeEnvironment) => {
-        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(hre.network.name).address;
-
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(hre.network.name);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const deployer = wallet.connect(provider);
+        const blockchainNetwork = hre.network.name;
+        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(blockchainNetwork).address;
+    
+        const signer = getSigner(blockchainNetwork);
 
         const spinner: Spinner = new Spinner();
 
-        console.log(`ℹ️  Attempting to deploy BasicMessageReceiver on the ${hre.network.name} blockchain using ${deployer.address} address, with the Router address ${routerAddress} provided as constructor argument`);
+        console.log(`ℹ️  Attempting to deploy BasicMessageReceiver on the ${blockchainNetwork} blockchain using ${signer.address} address, with the Router address ${routerAddress} provided as constructor argument`);
         spinner.start();
 
-        const basicMessageReceiverFactory: BasicMessageReceiver__factory = await hre.ethers.getContractFactory('BasicMessageReceiver') as BasicMessageReceiver__factory;
-        const basicMessageReceiver: BasicMessageReceiver = await basicMessageReceiverFactory.deploy(routerAddress);
+        const basicMessageReceiverFactory = await hre.ethers.getContractFactory('BasicMessageReceiver');
+        const basicMessageReceiver = await basicMessageReceiverFactory.deploy(routerAddress);
         await basicMessageReceiver.deployed();
 
         spinner.stop();
-        console.log(`✅ Basic Message Receiver deployed at address ${basicMessageReceiver.address} on ${hre.network.name} blockchain`)
+        console.log(`✅ Basic Message Receiver deployed at address ${basicMessageReceiver.address} on ${blockchainNetwork} blockchain`)
     });

--- a/tasks/deploy-basic-message-sender.ts
+++ b/tasks/deploy-basic-message-sender.ts
@@ -1,34 +1,28 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getRouterConfig, getSigner } from "./utils";
 import { Spinner } from "../utils/spinner";
 import { LINK_ADDRESSES } from "./constants";
-import { BasicMessageSender, BasicMessageSender__factory } from "../typechain-types";
 
 task(`deploy-basic-message-sender`, `Deploys the BasicMessageSender smart contract`)
     .addOptionalParam(`router`, `The address of the Router contract`)
     .addOptionalParam(`link`, `The address of the LINK token`)
     .setAction(async (taskArguments: TaskArguments, hre: HardhatRuntimeEnvironment) => {
-        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(hre.network.name).address;
-        const linkAddress = taskArguments.link ? taskArguments.link : LINK_ADDRESSES[hre.network.name]
+        const blockchainNetwork = hre.network.name;
+        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(blockchainNetwork).address;
+        const linkAddress = taskArguments.link ? taskArguments.link : LINK_ADDRESSES[blockchainNetwork]
 
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(hre.network.name);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const deployer = wallet.connect(provider);
+        const signer = getSigner(blockchainNetwork);
 
         const spinner: Spinner = new Spinner();
 
-        console.log(`ℹ️  Attempting to deploy BasicMessageSender on the ${hre.network.name} blockchain using ${deployer.address} address, with the Router address ${routerAddress} and LINK address ${linkAddress} provided as constructor arguments`);
+        console.log(`ℹ️  Attempting to deploy BasicMessageSender on the ${blockchainNetwork} blockchain using ${signer.address} address, with the Router address ${routerAddress} and LINK address ${linkAddress} provided as constructor arguments`);
         spinner.start();
 
-        const basicMessageSenderFactory: BasicMessageSender__factory = await hre.ethers.getContractFactory('BasicMessageSender') as BasicMessageSender__factory;
-        const basicMessageSender: BasicMessageSender = await basicMessageSenderFactory.deploy(routerAddress, linkAddress);
+        const basicMessageSenderFactory = await hre.ethers.getContractFactory('BasicMessageSender');
+        const basicMessageSender = await basicMessageSenderFactory.deploy(routerAddress, linkAddress);
         await basicMessageSender.deployed();
 
         spinner.stop();
-        console.log(`✅ BasicMessageSender deployed at address ${basicMessageSender.address} on ${hre.network.name} blockchain`)
+        console.log(`✅ BasicMessageSender deployed at address ${basicMessageSender.address} on ${blockchainNetwork} blockchain`)
     });

--- a/tasks/deploy-basic-token-sender.ts
+++ b/tasks/deploy-basic-token-sender.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getRouterConfig, getSigner } from "./utils";
 import { Spinner } from "../utils/spinner";
 import { LINK_ADDRESSES } from "./constants";
 
@@ -9,19 +8,14 @@ task(`deploy-basic-token-sender`, `Deploys the BasicTokenSender smart contract`)
     .addOptionalParam(`router`, `The address of the Router contract`)
     .addOptionalParam(`link`, `The address of the LINK token`)
     .setAction(async (taskArguments: TaskArguments, hre: HardhatRuntimeEnvironment) => {
-        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(hre.network.name).address;
-        const linkAddress = taskArguments.link ? taskArguments.link : LINK_ADDRESSES[hre.network.name]
+        const blockchainNetwork = hre.network.name;
+        const routerAddress = taskArguments.router ? taskArguments.router : getRouterConfig(blockchainNetwork).address;
+        const linkAddress = taskArguments.link ? taskArguments.link : LINK_ADDRESSES[blockchainNetwork]
 
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(hre.network.name);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const deployer = wallet.connect(provider);
-
+        const signer = getSigner(blockchainNetwork);
         const spinner: Spinner = new Spinner();
 
-        console.log(`ℹ️  Attempting to deploy BasicTokenSender on the ${hre.network.name} blockchain using ${deployer.address} address, with the Router address ${routerAddress} and LINK address ${linkAddress} provided as constructor arguments`);
+        console.log(`ℹ️  Attempting to deploy BasicTokenSender on the ${blockchainNetwork} blockchain using ${signer.address} address, with the Router address ${routerAddress} and LINK address ${linkAddress} provided as constructor arguments`);
         spinner.start();
 
         const basicTokenSenderFactory = await hre.ethers.getContractFactory('BasicTokenSender');
@@ -29,5 +23,5 @@ task(`deploy-basic-token-sender`, `Deploys the BasicTokenSender smart contract`)
         await basicTokenSender.deployed();
 
         spinner.stop();
-        console.log(`✅ Basic Token Sender deployed at address ${basicTokenSender.address} on the ${hre.network.name} blockchain`)
+        console.log(`✅ Basic Token Sender deployed at address ${basicTokenSender.address} on the ${blockchainNetwork} blockchain`)
     });

--- a/tasks/faucet.ts
+++ b/tasks/faucet.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getFaucetTokensAddresses } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getFaucetTokensAddresses, getSigner } from "./utils";
 import { BurnMintERC677Helper, BurnMintERC677Helper__factory } from "../typechain-types";
 import { Spinner } from "../utils/spinner";
 
@@ -12,19 +11,14 @@ task(`faucet`, `Mints 10**18 units of CCIP-BnM and CCIP-LnM tokens to receiver a
     .addOptionalParam(`ccipLnm`, `The address of the CCIP-LnM token`)
     .setAction(async (taskArguments: TaskArguments, hre: HardhatRuntimeEnvironment) => {
         const { receiver, ccipBnm, ccipLnm } = taskArguments;
+        const blockchainNetwork = hre.network.name;
+        const ccipBnmAddress = ccipBnm ? ccipBnm : getFaucetTokensAddresses(blockchainNetwork).ccipBnM;
 
-        const ccipBnmAddress = ccipBnm ? ccipBnm : getFaucetTokensAddresses(hre.network.name).ccipBnM;
-
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(hre.network.name);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(provider);
+        const signer = getSigner(blockchainNetwork);
 
         const spinner: Spinner = new Spinner();
 
-        console.log(`ℹ️  Attempting to mint 10**18 units of CCIP-BnM token (${ccipBnmAddress}) on ${hre.network.name} blockchain`);
+        console.log(`ℹ️  Attempting to mint 10**18 units of CCIP-BnM token (${ccipBnmAddress}) on ${blockchainNetwork} blockchain`);
         spinner.start();
 
         const ccipBnM: BurnMintERC677Helper = BurnMintERC677Helper__factory.connect(ccipBnmAddress, signer);
@@ -36,10 +30,10 @@ task(`faucet`, `Mints 10**18 units of CCIP-BnM and CCIP-LnM tokens to receiver a
 
         console.log(`ℹ️  CCIP-LnM tokens can be minted only on Ethereum Sepolia testnet`);
 
-        if (hre.network.name === `ethereumSepolia`) {
-            const ccipLnmAddress = ccipLnm ? ccipLnm : getFaucetTokensAddresses(hre.network.name).ccipLnM;
+        if (blockchainNetwork === `ethereumSepolia`) {
+            const ccipLnmAddress = ccipLnm ? ccipLnm : getFaucetTokensAddresses(blockchainNetwork).ccipLnM;
 
-            console.log(`ℹ️  Attempting to mint 10**18 units of CCIP-LnM token (${ccipLnmAddress}) on ${hre.network.name} blockchain`);
+            console.log(`ℹ️  Attempting to mint 10**18 units of CCIP-LnM token (${ccipLnmAddress}) on ${blockchainNetwork} blockchain`);
             spinner.start();
 
             const ccipLnM: BurnMintERC677Helper = BurnMintERC677Helper__factory.connect(ccipLnmAddress, signer);

--- a/tasks/fill-sender.ts
+++ b/tasks/fill-sender.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getPayFeesIn } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getPayFeesIn, getSigner } from "./utils";
 import { IERC20, IERC20__factory } from "../typechain-types";
 import { LINK_ADDRESSES, PayFeesIn } from "./constants";
 import { Spinner } from "../utils/spinner";
@@ -15,12 +14,7 @@ task(`fill-sender`, `Transfers the provided amount of LINK token or native coin 
     .setAction(async (taskArguments: TaskArguments) => {
         const { senderAddress, blockchain, amount, payFeesIn } = taskArguments;
 
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(blockchain);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(provider);
+        const signer = getSigner(blockchain);
 
         const fees = getPayFeesIn(payFeesIn);
 

--- a/tasks/get-message.ts
+++ b/tasks/get-message.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment, TaskArguments } from "hardhat/types";
-import { getProviderRpcUrl } from "./utils";
-import { providers } from "ethers";
+import { getProvider } from "./utils";
 import { BasicMessageReceiver__factory, BasicMessageReceiver } from "../typechain-types";
 import { Spinner } from "../utils/spinner";
 
@@ -11,8 +10,7 @@ task(`get-message`, `Gets BasicMessageSender latest received message details`)
     .setAction(async (taskArguments: TaskArguments, hre: HardhatRuntimeEnvironment) => {
         const { receiverAddress, blockchain } = taskArguments;
 
-        const rpcProviderUrl = getProviderRpcUrl(blockchain);
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
+        const provider = getProvider(blockchain);
 
         const basicMessageReceiver: BasicMessageReceiver = BasicMessageReceiver__factory.connect(receiverAddress, provider);
 

--- a/tasks/send-message.ts
+++ b/tasks/send-message.ts
@@ -2,8 +2,7 @@
 
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
-import { getPayFeesIn, getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getPayFeesIn, getRouterConfig, getSigner } from "./utils";
 import { BasicMessageSender, BasicMessageSender__factory } from "../typechain-types";
 import { Spinner } from "../utils/spinner";
 
@@ -17,12 +16,7 @@ task(`send-message`, `Sends basic text messages`)
     .setAction(async (taskArguments: TaskArguments) => {
         const { sourceBlockchain, sender, destinationBlockchain, receiver, message, payFeesIn } = taskArguments;
 
-        const privateKey = getPrivateKey();
-        const sourceRpcProviderUrl = getProviderRpcUrl(sourceBlockchain);
-
-        const sourceProvider = new providers.JsonRpcProvider(sourceRpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(sourceProvider);
+        const signer = getSigner(sourceBlockchain);
 
         const spinner: Spinner = new Spinner();
 

--- a/tasks/send-token-and-data.ts
+++ b/tasks/send-token-and-data.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl, getRouterConfig } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getRouterConfig, getSigner } from "./utils";
 import { IRouterClient, IRouterClient__factory, ProgrammableTokenTransfers, ProgrammableTokenTransfers__factory } from "../typechain-types";
 import { Spinner } from "../utils/spinner";
 
@@ -17,12 +16,7 @@ task(`send-token-and-data`, `Sends token and data using ProgrammableTokenTransfe
     .setAction(async (taskArguments: TaskArguments) => {
         const { sourceBlockchain, sender, destinationBlockchain, receiver, message, tokenAddress, amount } = taskArguments;
 
-        const privateKey = getPrivateKey();
-        const sourceRpcProviderUrl = getProviderRpcUrl(sourceBlockchain);
-
-        const sourceProvider = new providers.JsonRpcProvider(sourceRpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(sourceProvider);
+        const signer = getSigner(sourceBlockchain);
 
         const senderContract: ProgrammableTokenTransfers = ProgrammableTokenTransfers__factory.connect(sender, signer);
 
@@ -62,8 +56,7 @@ task(`get-received-message-details`, `Gets details of any CCIP message received 
     .setAction(async (taskArguments: TaskArguments) => {
         const { contractAddress, blockchain } = taskArguments;
 
-        const rpcProviderUrl = getProviderRpcUrl(blockchain);
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
+        const { provider } = getSignerAndProvider(blockchain);
 
         const receiverContract: ProgrammableTokenTransfers = ProgrammableTokenTransfers__factory.connect(contractAddress, provider);
 

--- a/tasks/utils.ts
+++ b/tasks/utils.ts
@@ -1,3 +1,4 @@
+import { Wallet, providers } from "ethers";
 import { CCIP_BnM_ADDRESSES, CCIP_LnM_ADDRESSES, PayFeesIn, routerConfig } from "./constants";
 
 export const getProviderRpcUrl = (network: string) => {
@@ -97,4 +98,50 @@ export const getPayFeesIn = (payFeesIn: string) => {
 
 export const getFaucetTokensAddresses = (network: string) => {
     return { ccipBnM: CCIP_BnM_ADDRESSES[network], ccipLnM: CCIP_LnM_ADDRESSES[network] };
+}
+
+/**
+ * The function `getSignerAndProvider` returns a provider and signer object for a given network using a
+ * private key and RPC provider URL.
+ * @param {string} network - The `network` parameter is a string that represents the network you want
+ * to connect to. It could be the name of a specific blockchain network like "mainnet" or "ropsten", or
+ * it could be a custom network configuration.
+ * @returns An object is being returned with two properties: "provider" and "signer".
+ */
+export const getSignerAndProvider = (network: string) => {
+    const privateKey = getPrivateKey();
+    const rpcProviderUrl = getProviderRpcUrl(network);
+    const provider = new providers.JsonRpcProvider(rpcProviderUrl);
+    const wallet = new Wallet(privateKey);
+    const signer = wallet.connect(provider);
+    return {
+        provider,
+        signer
+    };
+}
+
+/**
+ * The function `getSigner` returns the signer from the `getSignerAndProvider` function based on the
+ * provided network.
+ * @param {string} network - The `network` parameter is a string that represents the network on which
+ * the signer will be used. It could be the name or identifier of a specific blockchain network, such
+ * as "mainnet", "ropsten", "rinkeby", etc.
+ * @returns The `signer` object is being returned.
+ */
+export const getSigner = (network: string) => {
+    const { signer } = getSignerAndProvider(network);
+    return signer;
+}
+
+/**
+ * The function `getProvider` returns the provider from the `getSignerAndProvider` function based on
+ * the specified network.
+ * @param {string} network - The `network` parameter is a string that represents the network on which
+ * the provider is being used. It could be the name of a blockchain network such as "mainnet",
+ * "ropsten", "rinkeby", etc.
+ * @returns The provider object is being returned.
+ */
+export const getProvider = (network: string) => {
+    const { provider } = getSignerAndProvider(network);
+    return provider;
 }

--- a/tasks/withdraw.ts
+++ b/tasks/withdraw.ts
@@ -1,7 +1,6 @@
 import { task } from "hardhat/config";
 import { TaskArguments } from "hardhat/types";
-import { getPrivateKey, getProviderRpcUrl } from "./utils";
-import { Wallet, providers } from "ethers";
+import { getSigner } from "./utils";
 import { Withdraw } from "../typechain-types/artifacts/contracts/utils";
 import { Withdraw__factory } from "../typechain-types/factories/artifacts/contracts/utils";
 import { Spinner } from "../utils/spinner";
@@ -14,12 +13,7 @@ task(`withdraw`, `Withdraws tokens and coins from Withdraw.sol. Must be called b
     .setAction(async (taskArguments: TaskArguments) => {
         const { blockchain, from, beneficiary, tokenAddress } = taskArguments;
 
-        const privateKey = getPrivateKey();
-        const rpcProviderUrl = getProviderRpcUrl(blockchain);
-
-        const provider = new providers.JsonRpcProvider(rpcProviderUrl);
-        const wallet = new Wallet(privateKey);
-        const signer = wallet.connect(provider);
+        const signer = getSigner(blockchain);
 
         const withdraw: Withdraw = Withdraw__factory.connect(from, signer);
 


### PR DESCRIPTION
### Description

Same as that of mentioned in #8 

- Adds `getSigner`, `getProvider` & `getSignerAndProvider` in `tasks/utils.ts`
    
    - The functions `getSigner`, `getProvider` internally calls `getSignerAndProvider`, since one function should do one job. There are instances in the codebase wherein, sometimes, only the signer is needed and sometimes only the provider is needed and sometimes both are needed, thus, the above 3 different functions.

- Having `hre.network.name` was redundant and was impacting the code readbility, hence, created a variable

    `const blockchainNetwork = hre.network.name`

    - And replaced all occurences of `hre.network.name` with `blockchainNetwork`.

- @zeuslawyer  @andrejrakic  As discussed in #8, I did gave a thought about creating a new file `setup.ts` and having a function `accountAndNetworkSetup`, however, once I went through all the tasks, having `getSigner, getProvider & getSignerAndProvider` in `utils.ts`  made more sense, thus, proposing this PR accordingly.

### Closes

#8 

Please do let me know in case of any improvements/suggestions/feedbacks.

Happy to help and contribute for open source learning!