### PR TITLE
Update to CCIP 2.0 beta, CrossChainToken, and FinalityCodec

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "libs/chainlink-ccip"]
-	path = libs/chainlink-ccip
-	url = https://github.com/smartcontractkit/chainlink-ccip.git
-	branch = develop

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,7 +5,7 @@
 
 # CCIP v2.0
 - [Example 01: Token Transfer + Faster Than Finality](./examples/example01-token-transfer-faster-than-finality.md)
-- [Example 02: Hello World to BasicMessageReceiver (Faster Than Finality)](./examples/example02-hello-world-to-basic-message-receiver.md)
+- [Example 02: Hello World to BasicMessageReceiverWithCCVs (Faster Than Finality)](./examples/example02-hello-world-to-basic-message-receiver.md)
 - [Example 03: Programmable Token Transfer (Faster Than Finality)](./examples/example03-programmable-token-transfer-data-and-token.md)
 - [Example 04: Programmable Token Transfer (Default Finality + Sender Contract)](./examples/example04-programmable-token-transfer-default-finality-sender-contract.md)
 - [Example 05: ExtraArgsV3 No-Execution-Tag (Manual Execution Path)](./examples/example05-extraargsv3-no-execution-tag-manual-execution.md)

--- a/book/src/examples/example01-token-transfer-faster-than-finality.md
+++ b/book/src/examples/example01-token-transfer-faster-than-finality.md
@@ -7,7 +7,7 @@ Task: `example01` (implementation: `tasks/example01.ts`).
 ## What You Will Do
 
 1. Mint 1 CCIP-BnM token to your EOA with the `faucet` task.
-2. (Optional) Check the executor minimum block confirmations with the `executor-min-block-confirmations` task.
+2. (Optional) Check the executor allowed finality config with the `executor-allowed-finality-config` task.
 3. Send that token from source chain to destination chain with the `example01` task.
 
 ## Before You Start
@@ -32,20 +32,20 @@ Use the faucet task on the source chain. Pass the CCIP-BnM token address for tha
 npx hardhat faucet --network <NETWORK_NAME> --ccip-bnm <CCIP_BNM_TOKEN_ADDRESS>
 ```
 
-## Step 2: (Optional) Check Executor Minimum Block Confirmations
+## Step 2: (Optional) Check Executor Allowed Finality
 
-Before picking a block depth for Faster Than Finality, you can read the executor minimum with the Hardhat task:
+Before picking a block depth for Faster Than Finality, you can read the executor’s allowed finality (`FinalityCodec` `bytes4`) with:
 
 ```bash
-npx hardhat executor-min-block-confirmations --network <NETWORK_NAME> --executor <EXECUTOR_ADDRESS>
+npx hardhat executor-allowed-finality-config --network <NETWORK_NAME> --executor <EXECUTOR_ADDRESS>
 ```
 
-The task prints: `Min block confirmations <uint16>`.
+The task prints: `Allowed finality config (bytes4) 0x…`.
 
 Why this matters:
 
-- If your requested `blockConfirmations` is below the executor minimum, the send can revert.
-- If your requested `blockConfirmations` is greater than chain finality, default finality is used.
+- Your requested finality in `ExtraArgsV3` must be **allowed** by the executor and destination policy (`FinalityCodec`); mismatches can revert.
+- If your requested mode is stricter than needed, behavior follows CCIP / pool rules (see chain-specific docs).
 
 ## Step 3: Send Token With Faster Than Finality
 

--- a/book/src/examples/example02-hello-world-to-basic-message-receiver.md
+++ b/book/src/examples/example02-hello-world-to-basic-message-receiver.md
@@ -53,7 +53,7 @@ As a convenience, applications generally inherited `CCIPReceiver.sol` and implem
 
 ### CCIP v2.0
 
-In v2.0, receivers expose Cross Chain Verifiers and finality requirements via `getCCVsAndMinBlockDepth`:
+In v2.0, receivers expose Cross Chain Verifiers and finality requirements via `getCCVsAndFinalityConfig` (encoded with `FinalityCodec` as `bytes4 allowedFinalityConfig`):
 
 ```ts
 // SPDX-License-Identifier: MIT
@@ -66,7 +66,7 @@ interface IAny2EVMMessageReceiverV2 {
     Client.Any2EVMMessage calldata message
   ) external;
 
- function getCCVsAndMinBlockDepth(
+  function getCCVsAndFinalityConfig(
     uint64 sourceChainSelector,
     bytes calldata sender
   )
@@ -76,7 +76,7 @@ interface IAny2EVMMessageReceiverV2 {
       address[] memory requiredCCVs,
       address[] memory optionalCCVs,
       uint8 optionalThreshold,
-      uint16 minBlockDepth
+      bytes4 allowedFinalityConfig
     );
 }
 ```
@@ -84,15 +84,11 @@ interface IAny2EVMMessageReceiverV2 {
 The receiver controls two independent dimensions:
 
 - `requiredCCVs` and `optionalCCVs` define additional verifiers required for acceptance.
-- `minBlockDepth` defines minimum block depth for Faster Than Finality execution.
-- `minBlockDepth = 0` means default finality is required.
+- `allowedFinalityConfig` defines which requested finality modes are accepted (see `FinalityCodec` in chainlink-ccip). A zero value (`WAIT_FOR_FINALITY_FLAG`) means only fully finalized messages are accepted.
 
-You can combine these independently:
+You can combine these independently (for example, add verifiers while requiring full finality, or allow faster-than-finality modes when policy allows).
 
-- Add additional verifiers while keeping `minBlockDepth = 0`.
-- Use default verifiers only, while setting `minBlockDepth > 0`.
-
-In this starter kit, `contracts/BasicMessageReceiverWithCCVs.sol` adds configurable verifier sets and configurable minimum block depth.
+In this starter kit, `contracts/BasicMessageReceiverWithCCVs.sol` adds configurable verifier sets and stores a per-chain minimum block depth, which it exposes via `FinalityCodec._encodeBlockDepth` in `getCCVsAndFinalityConfig`.
 
 ## Step 1: Deploy `BasicMessageReceiverWithCCVs` on Destination Chain
 

--- a/book/src/examples/example02-hello-world-to-basic-message-receiver.md
+++ b/book/src/examples/example02-hello-world-to-basic-message-receiver.md
@@ -1,18 +1,20 @@
-# Example 02: Hello World to BasicMessageReceiver (Faster Than Finality)
+# Example 02: Hello World to BasicMessageReceiverWithCCVs (Faster Than Finality)
 
-This example deploys a destination receiver contract and sends a Hello World data message to it from an EOA using Faster Than Finality (`blockConfirmations > 0`).
+This example deploys a destination `BasicMessageReceiverWithCCVs` contract and sends a Hello World data message from an EOA using Faster Than Finality (`blockConfirmations > 0`).
 
 Tasks and modules used:
 
-- **Deploy receiver:** Hardhat Ignition module `ignition/modules/BasicMessageReceiver.ts` (deploy on destination chain).
+- **Deploy receiver:** Hardhat Ignition module `ignition/modules/BasicMessageReceiverWithCCVs.ts` (deploy on destination chain).
+- **Configure min block depth:** Hardhat task `set-basic-message-receiver-with-ccvs-min-block-depth` (implementation: `tasks/helpers/SetBasicMessageReceiverWithCCVsMinBlockDepth.ts`).
 - **Send message:** Hardhat task `example02` (implementation: `tasks/Example02.ts`).
 - **Read latest message:** Hardhat task `basic-message-receiver-latest-message` (implementation: `tasks/helpers/BasicMessageReceiverLatestMessage.ts`).
 
 ## What You Will Do
 
-1. Deploy `BasicMessageReceiver` on the destination chain using Ignition.
-2. Send a Hello World CCIP data message from source chain to the deployed receiver using the `example02` task.
-3. (Optional) Verify the received message with the `basic-message-receiver-latest-message` task.
+1. Deploy `BasicMessageReceiverWithCCVs` on the destination chain using Ignition.
+2. Configure minimum block depth for the source chain.
+3. Send a Hello World CCIP data message from the source chain to `BasicMessageReceiverWithCCVs` using the `example02` task.
+4. (Optional) Verify the received message with the `basic-message-receiver-latest-message` task.
 
 ## Before You Start
 
@@ -51,7 +53,7 @@ As a convenience, applications generally inherited `CCIPReceiver.sol` and implem
 
 ### CCIP v2.0
 
-In v2.0, receivers expose CCV and finality requirements via `getCCVsAndMinBlockDepth`:
+In v2.0, receivers expose Cross Chain Verifiers and finality requirements via `getCCVsAndMinBlockDepth`:
 
 ```ts
 // SPDX-License-Identifier: MIT
@@ -79,26 +81,50 @@ interface IAny2EVMMessageReceiverV2 {
 }
 ```
 
-`minBlockDepth = 0` means finality is required. Any non-zero value allows Faster Than Finality messages with sufficient block depth.
+The receiver controls two independent dimensions:
 
-In this starter kit:
+- `requiredCCVs` and `optionalCCVs` define additional verifiers required for acceptance.
+- `minBlockDepth` defines minimum block depth for Faster Than Finality execution.
+- `minBlockDepth = 0` means default finality is required.
 
-- `contracts/BasicMessageReceiver.sol` is the baseline receiver flow used in this example.
-- `contracts/BasicMessageReceiverWithCCVs.sol` extends it with configurable `getCCVsAndMinBlockDepth` behavior for Modular Trust Layer examples.
+You can combine these independently:
 
-## Step 1: Deploy `BasicMessageReceiver` on Destination Chain
+- Add additional verifiers while keeping `minBlockDepth = 0`.
+- Use default verifiers only, while setting `minBlockDepth > 0`.
+
+In this starter kit, `contracts/BasicMessageReceiverWithCCVs.sol` adds configurable verifier sets and configurable minimum block depth.
+
+## Step 1: Deploy `BasicMessageReceiverWithCCVs` on Destination Chain
 
 Deploy the receiver on the **destination** chain using Hardhat Ignition.
 
 ```bash
-npx hardhat ignition deploy ignition/modules/BasicMessageReceiver.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
+npx hardhat ignition deploy ignition/modules/BasicMessageReceiverWithCCVs.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
 ```
 
 `--parameters` must be the path to the chain's Ignition parameters JSON (e.g. `ignition/paramsFuji.json` or `ignition/paramsEthSepolia.json`). That file supplies router and other addresses to the module.
 
-Save the deployed receiver address from the deployment output (e.g. from `deployed_addresses.json` or the console).
+Save the deployed address as `<BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>`.
 
-## Step 2: Send Hello World Data Message from EOA
+By default, this receiver starts with `minBlockDepth = 0` (default finality only) for all source chains until you configure it.
+
+## Step 2: Configure Minimum Block Depth for Your Source Chain
+
+On the **destination** chain, run:
+
+```bash
+npx hardhat set-basic-message-receiver-with-ccvs-min-block-depth --network <NETWORK_NAME> \
+  --receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
+  --source-chain-selector <SOURCE_CHAIN_SELECTOR> \
+  --min-block-depth <MIN_BLOCK_DEPTH>
+```
+
+For this chapter, use `<MIN_BLOCK_DEPTH> = 1`.
+
+- `0` means default finality-only behavior for that source chain.
+- `> 0` enables Faster Than Finality with that minimum depth.
+
+## Step 3: Send Hello World Data Message from EOA
 
 From the **source** chain, run the `example02` task. Pass the deployed receiver address as `--receiver` and your message as `--message-text`.
 
@@ -106,7 +132,7 @@ From the **source** chain, run the `example02` task. Pass the deployed receiver 
 npx hardhat example02 --network <NETWORK_NAME> \
   --source-router <SOURCE_ROUTER> \
   --destination-chain-selector <DESTINATION_CHAIN_SELECTOR> \
-  --receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS> \
+  --receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
   --message-text "Hello, World" \
   --gas-limit <GAS_LIMIT> \
   --block-confirmations <BLOCK_CONFIRMATIONS_GT_ZERO> \
@@ -115,8 +141,9 @@ npx hardhat example02 --network <NETWORK_NAME> \
 
 Parameter notes:
 
-- `--gas-limit` must be `> 0` because the destination receiver contract callback needs gas (e.g. `200000`).
+- `--gas-limit` must be `> 0` because the destination receiver callback needs gas (e.g. `200000`).
 - `--block-confirmations` must be `> 0` for Faster Than Finality.
+- `--block-confirmations` should be greater than or equal to `<MIN_BLOCK_DEPTH>`.
 - Executor may enforce a minimum block confirmations value and revert if too low.
 - If requested confirmations exceed chain finality, default finality is used.
 - `--fee-token-address`: LINK token address on the source chain to pay fees in LINK, or `0x0000000000000000000000000000000000000000` to pay in native coin.
@@ -132,6 +159,7 @@ The `example02` task logs the CCIP message ID and a link to monitor.
 **Read the latest message on the receiver** (destination chain). The task decodes the stored bytes as the string that was sent:
 
 ```bash
-npx hardhat basic-message-receiver-latest-message --network <NETWORK_NAME> --basic-message-receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS>
+npx hardhat basic-message-receiver-latest-message --network <NETWORK_NAME> --basic-message-receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>
 ```
+
 Output is the decoded string (e.g. `Hello, World`). If no message has been received yet, the task prints `(empty)`.

--- a/book/src/examples/example03-programmable-token-transfer-data-and-token.md
+++ b/book/src/examples/example03-programmable-token-transfer-data-and-token.md
@@ -55,6 +55,8 @@ This chapter uses Faster Than Finality (`blockConfirmations > 0`), so the destin
 >
 > For this chapter (which sends Faster Than Finality), use `<MIN_BLOCK_DEPTH> > 0`.
 >
+> The user-facing input for this example is `--min-block-depth <MIN_BLOCK_DEPTH>` (a `uint16` passed to `BasicMessageReceiverWithCCVs.setMinBlockDepth`). On-chain, the receiver does not return that integer directly to CCIP: `getCCVsAndFinalityConfig` sets `allowedFinalityConfig` to `FinalityCodec._encodeBlockDepth(minBlockDepth)` — the same `bytes4` finality encoding CCIP 2.0 uses elsewhere for allowed finality (depth `0` means wait for full/default finality).
+>
 > `--parameters` is the path to the chain's Ignition parameters JSON (e.g. `ignition/paramsEthSepolia.json`); it supplies router and other addresses to the module.
 >
 > Save the deployed receiver address and use it as `--receiver` in Step 2.
@@ -89,8 +91,7 @@ Parameter notes:
 - `--amount`: token amount in wei (e.g. `1000000000000000000` for 1 token with 18 decimals).
 - `--gas-limit` must be `> 0` because the receiver contract callback handles data (e.g. `200000`).
 - `--block-confirmations` must be `> 0` for Faster Than Finality.
-- If `<BLOCK_CONFIRMATIONS> > 0`, the destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) for this source chain.
-- If `<BLOCK_CONFIRMATIONS> = 0`, a default-finality receiver is sufficient.
+- `--block-confirmations` should be greater than or equal to `<MIN_BLOCK_DEPTH>` (the depth you stored on the receiver; CCIP compares it against your message’s `requestedFinalityConfig` after both sides use `FinalityCodec` encoding).
 - Executor may enforce a minimum block confirmation value and revert if too low.
 - If requested confirmations exceed chain finality, default finality is used.
 - `--fee-token-address`: LINK token address on the source chain to pay fees in LINK, or `0x0000000000000000000000000000000000000000` to pay in native coin.

--- a/book/src/examples/example03-programmable-token-transfer-data-and-token.md
+++ b/book/src/examples/example03-programmable-token-transfer-data-and-token.md
@@ -1,6 +1,6 @@
-# Example 03: Programmable Token Transfer (Hello World + CCIP-BnM)
+# Example 03: Programmable Token Transfer (Faster Than Finality)
 
-This example sends a programmable token transfer from an EOA on Avalanche Fuji to a `BasicMessageReceiver` on Ethereum Sepolia:
+This example sends a programmable token transfer from an EOA on Avalanche Fuji to a receiver that supports Faster Than Finality on Ethereum Sepolia:
 
 - Data payload: `"Hello, World"`
 - Tokens: `CCIP-BnM`
@@ -9,10 +9,18 @@ Task: `example03` (implementation: `tasks/Example03.ts`).
 
 ## What You Will Do
 
-1. Ensure a destination `BasicMessageReceiver` exists on Sepolia (deploy via Ignition if needed).
+1. Ensure a destination `BasicMessageReceiverWithCCVs` exists on Sepolia.
 2. Mint 1 `CCIP-BnM` on Fuji using the `faucet` task.
 3. Send one CCIP message containing both data and tokens using the `example03` task.
 4. (Optional) Verify receiver state with the `basic-message-receiver-latest-*` tasks.
+
+## Receiver Compatibility Note
+
+This chapter uses Faster Than Finality (`blockConfirmations > 0`), so the destination receiver should return a non-zero minimum block depth for your source chain.
+
+- If your receiver is default-finality-only, this message can fail on destination.
+- Deploy `BasicMessageReceiverWithCCVs` before running this chapter and configure `setMinBlockDepth` for your source chain.
+- For default-finality programmable token transfer (`blockConfirmations = 0`), use Example 04.
 
 ## Before You Start
 
@@ -30,11 +38,22 @@ Task: `example03` (implementation: `tasks/Example03.ts`).
 
 > **If you do not have a receiver deployed yet**
 >
-> Deploy `BasicMessageReceiver` on Sepolia with Ignition (see Example 02):
+> Deploy `BasicMessageReceiverWithCCVs` on Sepolia with Ignition (see Example 02):
 >
 > ```bash
-> npx hardhat ignition deploy ignition/modules/BasicMessageReceiver.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
+> npx hardhat ignition deploy ignition/modules/BasicMessageReceiverWithCCVs.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
 > ```
+>
+> Then configure min block depth for your source chain:
+>
+> ```bash
+> npx hardhat set-basic-message-receiver-with-ccvs-min-block-depth --network <NETWORK_NAME> \
+>   --receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
+>   --source-chain-selector <SOURCE_CHAIN_SELECTOR> \
+>   --min-block-depth <MIN_BLOCK_DEPTH>
+> ```
+>
+> For this chapter (which sends Faster Than Finality), use `<MIN_BLOCK_DEPTH> > 0`.
 >
 > `--parameters` is the path to the chain's Ignition parameters JSON (e.g. `ignition/paramsEthSepolia.json`); it supplies router and other addresses to the module.
 >
@@ -56,7 +75,7 @@ From Fuji (source chain), run the `example03` task. Pass the deployed receiver o
 npx hardhat example03 --network <NETWORK_NAME> \
   --source-router <SOURCE_ROUTER> \
   --destination-chain-selector <DESTINATION_CHAIN_SELECTOR> \
-  --receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS> \
+  --receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
   --message-text "Hello, World" \
   --token-to-send <CCIP_BNM_FUJI_ADDRESS> \
   --amount <AMOUNT> \
@@ -70,6 +89,8 @@ Parameter notes:
 - `--amount`: token amount in wei (e.g. `1000000000000000000` for 1 token with 18 decimals).
 - `--gas-limit` must be `> 0` because the receiver contract callback handles data (e.g. `200000`).
 - `--block-confirmations` must be `> 0` for Faster Than Finality.
+- If `<BLOCK_CONFIRMATIONS> > 0`, the destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) for this source chain.
+- If `<BLOCK_CONFIRMATIONS> = 0`, a default-finality receiver is sufficient.
 - Executor may enforce a minimum block confirmation value and revert if too low.
 - If requested confirmations exceed chain finality, default finality is used.
 - `--fee-token-address`: LINK token address on the source chain to pay fees in LINK, or `0x0000000000000000000000000000000000000000` to pay in native coin.
@@ -82,15 +103,15 @@ The `example03` task logs the CCIP message ID and a link to monitor.
 
 **Monitor message status:** https://ccip.chain.link
 
-**Optional: read receiver state on Sepolia** using the Hardhat tasks (receiver address = `<DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS>`):
+**Optional: read receiver state on Sepolia** using the Hardhat tasks (receiver address = `<BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>`):
 
 ```bash
 # Decoded latest message (string)
-npx hardhat basic-message-receiver-latest-message --network <NETWORK_NAME> --basic-message-receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS>
+npx hardhat basic-message-receiver-latest-message --network <NETWORK_NAME> --basic-message-receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>
 
 # Latest sender address
-npx hardhat basic-message-receiver-latest-sender --network <NETWORK_NAME> --basic-message-receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS>
+npx hardhat basic-message-receiver-latest-sender --network <NETWORK_NAME> --basic-message-receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>
 
 # Latest source chain selector (uint64)
-npx hardhat basic-message-receiver-latest-source-chain-selector --network <NETWORK_NAME> --basic-message-receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS>
+npx hardhat basic-message-receiver-latest-source-chain-selector --network <NETWORK_NAME> --basic-message-receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>
 ```

--- a/book/src/examples/example04-programmable-token-transfer-default-finality-sender-contract.md
+++ b/book/src/examples/example04-programmable-token-transfer-default-finality-sender-contract.md
@@ -6,10 +6,13 @@ This example sends a programmable token transfer from Avalanche Fuji to Ethereum
 - Tokens: `CCIP-BnM`
 - Finality mode: default finality (`blockConfirmations = 0`)
 
+Because this chapter uses default finality, the baseline `BasicMessageReceiver` is sufficient on destination.
+If you want the Faster Than Finality variant (`blockConfirmations > 0`), use Example 03 with `BasicMessageReceiverWithCCVs`.
+
 Tasks and modules used:
 
 - **Deploy sender:** Hardhat Ignition module `ignition/modules/BasicMessageSender.ts` (deploy on source chain; requires `routerAddress` and `linkAddress` in params).
-- **Deploy receiver (if needed):** Hardhat Ignition module `ignition/modules/BasicMessageReceiver.ts` (see Example 02).
+- **Deploy receiver (if needed):** Hardhat Ignition module `ignition/modules/BasicMessageReceiver.ts` (this example; default finality).
 - **Mint token:** Hardhat task `faucet`.
 - **Send message:** Hardhat task `example04` (implementation: `tasks/Example04.ts`).
 - **Verify receiver:** Hardhat tasks `basic-message-receiver-latest-message`, `basic-message-receiver-latest-sender`, `basic-message-receiver-latest-source-chain-selector`.
@@ -17,7 +20,7 @@ Tasks and modules used:
 ## What You Will Do
 
 1. Deploy `BasicMessageSender` on the source chain (Fuji) using Ignition.
-2. Ensure destination `BasicMessageReceiver` exists on Sepolia (deploy via Ignition if needed; see Example 02).
+2. Ensure destination `BasicMessageReceiver` exists on Sepolia (deploy via Ignition if needed; see below).
 3. Mint 1 `CCIP-BnM` on Fuji using the `faucet` task.
 4. Run the `example04` task: it quotes the fee, funds the sender contract with that amount (when paying in native), then sends data + token.
 
@@ -37,7 +40,7 @@ Tasks and modules used:
 
 > **If you do not have a receiver deployed yet**
 >
-> Deploy `BasicMessageReceiver` on Sepolia with Ignition (see Example 02):
+> Deploy `BasicMessageReceiver` on Sepolia with Ignition:
 >
 > ```bash
 > npx hardhat ignition deploy ignition/modules/BasicMessageReceiver.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>

--- a/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
+++ b/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
@@ -6,7 +6,7 @@ Task: `example05` (implementation: `tasks/Example05.ts`).
 
 ## What You Will Do
 
-1. Ensure destination `BasicMessageReceiver` exists (deploy via Ignition if needed; see Example 02).
+1. Ensure a compatible destination receiver exists (default finality or Faster Than Finality based on your `blockConfirmations`).
 2. Send a CCIP data message with `ExtraArgsV3` no-execution-tag using the `example05` task.
 3. Observe pending execution in CCIP Explorer and execute manually.
 
@@ -26,15 +26,32 @@ Task: `example05` (implementation: `tasks/Example05.ts`).
 
 > **If you do not have a receiver deployed yet**
 >
-> Deploy `BasicMessageReceiver` on the destination chain with Ignition (see Example 02):
+> Choose deployment based on your `blockConfirmations`:
 >
 > ```bash
 > npx hardhat ignition deploy ignition/modules/BasicMessageReceiver.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
 > ```
 >
-> `--parameters` is the path to the chain's Ignition parameters JSON; it supplies router and other addresses to the module.
+> Use this for default finality (`blockConfirmations = 0`). Save this as `<BASIC_MESSAGE_RECEIVER_ADDRESS>`.
 >
-> Save the deployed receiver address for use as `--receiver` below.
+> ```bash
+> npx hardhat ignition deploy ignition/modules/BasicMessageReceiverWithCCVs.ts --network <NETWORK_NAME> --parameters <PARAMETERS_FILE>
+> ```
+>
+> If you use Faster Than Finality (`blockConfirmations > 0`), configure min block depth for your source chain:
+>
+> ```bash
+> npx hardhat set-basic-message-receiver-with-ccvs-min-block-depth --network <NETWORK_NAME> \
+>   --receiver <BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
+>   --source-chain-selector <SOURCE_CHAIN_SELECTOR> \
+>   --min-block-depth <MIN_BLOCK_DEPTH>
+> ```
+>
+> Use `<MIN_BLOCK_DEPTH> > 0` for Faster Than Finality.
+>
+> Use this for Faster Than Finality (`blockConfirmations > 0`). Save this as `<BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS>`.
+>
+> `--parameters` is the path to the chain's Ignition parameters JSON; it supplies router and other addresses to the module.
 
 ## Understanding ExtraArgsV3
 
@@ -77,7 +94,7 @@ Run the `example05` task. It sends a data-only message with executor set to `NO_
 npx hardhat example05 --network <NETWORK_NAME> \
   --source-router <SOURCE_ROUTER> \
   --destination-chain-selector <DESTINATION_CHAIN_SELECTOR> \
-  --receiver <DEPLOYED_BASIC_MESSAGE_RECEIVER_ADDRESS> \
+  --receiver <BASIC_MESSAGE_RECEIVER_ADDRESS_OR_BASIC_MESSAGE_RECEIVER_WITH_CCVS_ADDRESS> \
   --message-text "Hello, World" \
   --gas-limit <GAS_LIMIT> \
   --block-confirmations <BLOCK_CONFIRMATIONS> \
@@ -88,6 +105,8 @@ Parameter notes:
 
 - `--gas-limit` must be `> 0` because the receiver callback needs gas (e.g. `200000`).
 - `--block-confirmations` can be `0` (default finality) or `> 0`.
+- If `<BLOCK_CONFIRMATIONS> > 0`, destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) for this source chain.
+- If `<BLOCK_CONFIRMATIONS> = 0`, a default-finality receiver is sufficient.
 - `--fee-token-address`: LINK token address on the source chain to pay fees in LINK, or `0x0000000000000000000000000000000000000000` to pay in native coin.
 - This example sets executor to `NO_EXECUTION_ADDRESS`, so execution is not automatic; the message remains in a pending/manual execution state.
 

--- a/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
+++ b/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
@@ -82,6 +82,7 @@ struct GenericExtraArgsV3 {
 Related helpers in `scripts/CallEncodeExtraArgsOffchain.ts`:
 
 - `encodeV3Basic(gasLimit, blockConfirmations)` for a minimal V3 payload.
+- `encodeAllowedFinalityBlockDepthAndSafeFlag(blockDepth)` calls `EncodeExtraArgsOffchain.encodeAllowedFinalityBlockDepthAndSafeFlag`, which wraps `FinalityCodec._encodeBlockDepthAndSafeFlag` — for **allowed** finality (`bytes4`) on pools/receivers/policy, **not** for sender ExtraArgs `requestedFinalityConfig`.
 - `getNoExecutionAddress()` returns `Client.NO_EXECUTION_ADDRESS` for the manual execution path.
 
 The `example05` task uses these to build ExtraArgsV3 with the no-execution tag.

--- a/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
+++ b/book/src/examples/example05-extraargsv3-no-execution-tag-manual-execution.md
@@ -57,10 +57,10 @@ Task: `example05` (implementation: `tasks/Example05.ts`).
 
 The `ExtraArgsV3` is a structured set of delivery/execution options encoded and attached to a CCIP message.
 
-```c++
+```solidity
 struct GenericExtraArgsV3 {
     uint32 gasLimit;
-    uint16 blockConfirmations;
+    bytes4 requestedFinalityConfig;
     address[] ccvs;
     bytes[] ccvArgs;
     address executor;
@@ -70,8 +70,10 @@ struct GenericExtraArgsV3 {
 }
 ```
 
+(On-chain this struct lives in `ExtraArgsCodec` from `@chainlink/contracts-ccip`.)
+
 - `gasLimit`: gas allocated for callback execution on destination. If `0` and message data is empty, no callback executes.
-- `blockConfirmations`: confirmation depth before execution. `0` means default finality for the lane.
+- `requestedFinalityConfig`: `bytes4` finality mode + parameters per `FinalityCodec` (not a bare `uint16`). All-zero means wait for default/lane finality. For block-depth style faster-than-finality, encode with `FinalityCodec._encodeBlockDepth(uint16)` (see CCIP / `FinalityCodec` NatSpec). **Example05** and `EncodeExtraArgsOffchain.encodeV3` / `encodeV3Basic` take a `blockConfirmations` argument only as a convenience and set this field to `FinalityCodec._encodeBlockDepth(blockConfirmations)`.
 - `ccvs`: list of cross-chain verifier addresses. Empty means default verifiers.
 - `ccvArgs`: optional arguments for each CCV. Must match `ccvs` length.
 - `executor`: executor address on source chain. `address(0)` uses default executor.

--- a/book/src/examples/example06-cct01-burnmint-token-and-pool-setup.md
+++ b/book/src/examples/example06-cct01-burnmint-token-and-pool-setup.md
@@ -2,7 +2,7 @@
 
 This example covers the full BurnMint CCT flow on Fuji → Sepolia:
 
-1. Deploy BurnMint token + BurnMint pool on both chains (Hardhat Ignition).
+1. Deploy [`CrossChainToken`](https://github.com/smartcontractkit/chainlink-ccip/blob/develop/chains/evm/contracts/tokens/CrossChainToken.sol) + BurnMint pool on both chains (Hardhat Ignition).
 2. Configure pools to trust each other (`example06-step1`).
 3. Send a token transfer across the lane (`example06-step2`).
 4. Verify BurnMint behavior (burn on source, mint on destination) with helper tasks.
@@ -33,7 +33,7 @@ Modules and tasks used:
 
 The BurnMintTokenPool Ignition module deploys:
 
-- **Token:** `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply.
+- **Token:** **CrossChainToken** via `BaseERC20.ConstructorParams`: `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply. The deployer EOA is pre-mint recipient, CCIP admin, burn/mint admin, and default admin. Registration uses `RegistryModuleOwnerCustom.registerAdminViaGetCCIPAdmin`.
 - **Pool:** BurnMintTokenPool with no advanced pool hook (CCT 01).
 
 ## Step 1: Deploy Token + Pool on Fuji
@@ -46,7 +46,7 @@ npx hardhat ignition deploy ignition/modules/BurnMintTokenPool.ts --network <NET
 
 Save from the deployment output:
 
-- `<FUJI_TOKEN_ADDRESS>` (FactoryBurnMintERC20 / token)
+- `<FUJI_TOKEN_ADDRESS>` (CrossChainToken)
 - `<FUJI_POOL_ADDRESS>` (BurnMintTokenPool)
 
 ## Step 2: Deploy Token + Pool on Sepolia

--- a/book/src/examples/example07-cct02-lockrelease-token-and-pool-setup.md
+++ b/book/src/examples/example07-cct02-lockrelease-token-and-pool-setup.md
@@ -35,7 +35,7 @@ Modules and tasks used:
 
 The LockAndReleaseTokenPool Ignition module deploys:
 
-- **Token:** `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply.
+- **Token:** **CrossChainToken** with the same defaults and `registerAdminViaGetCCIPAdmin` flow as Example 06: `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply.
 - **Lock box:** ERC20LockBox bound to the token.
 - **Pool:** LockReleaseTokenPool with no advanced pool hook (CCT 02).
 
@@ -49,7 +49,7 @@ npx hardhat ignition deploy ignition/modules/LockAndReleaseTokenPool.ts --networ
 
 Save from the deployment output:
 
-- `<FUJI_TOKEN_ADDRESS>` (FactoryBurnMintERC20 / token)
+- `<FUJI_TOKEN_ADDRESS>` (CrossChainToken; same defaults as Example 06)
 - `<FUJI_LOCKBOX_ADDRESS>` (ERC20LockBox)
 - `<FUJI_POOL_ADDRESS>` (LockReleaseTokenPool)
 

--- a/book/src/examples/example08-cct03-burnmint-with-advanced-pool-hooks.md
+++ b/book/src/examples/example08-cct03-burnmint-with-advanced-pool-hooks.md
@@ -27,7 +27,7 @@ This flow still demonstrates the correct hook wiring pattern for ACE-enabled set
 
 ## What This Example Covers
 
-1. Deploy BurnMint token + `AdvancedPoolHooks` + BurnMint pool on both chains (Hardhat Ignition).
+1. Deploy CrossChainToken + `AdvancedPoolHooks` + BurnMint pool on both chains (Hardhat Ignition).
 2. Configure pools to trust each other (`example08-step1`).
 3. Send token transfer with ExtraArgsV3 default-finality sender (`example08-step2`).
 4. (Optional) Update hook allowlist (`example08-step3`).
@@ -60,7 +60,7 @@ Modules and tasks used:
 
 The BurnMintTokenPoolAdvancedPoolHook Ignition module deploys:
 
-- **Token:** `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply.
+- **Token:** **CrossChainToken** (same defaults and `registerAdminViaGetCCIPAdmin` flow as Example 06): `TestToken` (`TEST`), 18 decimals, 1_000_000 × 10¹⁸ premint, 100_000_000 × 10¹⁸ max supply.
 - **Hook:** AdvancedPoolHooks with allowlist seeded with deployer EOA, `thresholdAmountForAdditionalCCVs` from params, policy engine disabled, pool authorized as caller.
 - **Pool:** BurnMintTokenPool with the hook attached.
 

--- a/book/src/tools/ccip-sdk-ccip-send.md
+++ b/book/src/tools/ccip-sdk-ccip-send.md
@@ -16,6 +16,21 @@ This chapter shows how to run the SDK script for the three message shapes used i
 
 The script lives in `sdk-examples/src/ccip-send.ts`.
 
+## Receiver Compatibility for Faster Than Finality
+
+When using `--block-confirmations > 0` (Faster Than Finality), receiver compatibility matters for message modes that execute receiver callbacks.
+
+| Mode | `--block-confirmations 0` | `--block-confirmations > 0` |
+|---|---|---|
+| `data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
+| `token-data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
+| `token` with `--gas-limit 0` | callback not executed (EOA-style token receive path) | callback not executed (EOA-style token receive path) |
+
+Terminology note:
+
+- Sender side (`ExtraArgsV3`): `blockConfirmations`
+- Receiver side (`getCCVsAndMinBlockDepth`): `minBlockDepth`
+
 ## How This Script Uses the SDK
 
 At a high level, the script builds `EVMChain` instances for source and destination, asks the SDK for a fee quote, then submits the message via the SDK send call.

--- a/book/src/tools/ccip-sdk-ccip-send.md
+++ b/book/src/tools/ccip-sdk-ccip-send.md
@@ -22,14 +22,14 @@ When using `--block-confirmations > 0` (Faster Than Finality), receiver compatib
 
 | Mode | `--block-confirmations 0` | `--block-confirmations > 0` |
 |---|---|---|
-| `data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
-| `token-data` | baseline receiver works | destination receiver must accept Faster Than Finality (`minBlockDepth > 0`) |
+| `data` | baseline receiver works | destination receiver must allow the requested finality (see `getCCVsAndFinalityConfig` / `allowedFinalityConfig`) |
+| `token-data` | baseline receiver works | destination receiver must allow the requested finality (see `getCCVsAndFinalityConfig` / `allowedFinalityConfig`) |
 | `token` with `--gas-limit 0` | callback not executed (EOA-style token receive path) | callback not executed (EOA-style token receive path) |
 
 Terminology note:
 
-- Sender side (`ExtraArgsV3`): `blockConfirmations`
-- Receiver side (`getCCVsAndMinBlockDepth`): `minBlockDepth`
+- Sender side (`ExtraArgsV3`): requested finality (e.g. `FinalityCodec` / block depth in `requestedFinalityConfig`)
+- Receiver side (`getCCVsAndFinalityConfig`): `allowedFinalityConfig` (`bytes4`, `FinalityCodec`)
 
 ## How This Script Uses the SDK
 

--- a/contracts/BasicMessageReceiverWithCCVs.sol
+++ b/contracts/BasicMessageReceiverWithCCVs.sol
@@ -18,7 +18,6 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
         address[] requiredCCVs;
         address[] optionalCCVs;
         uint8 optionalThreshold;
-        bool requireFinality;
     }
 
     /// @notice Arguments required to add a CCV configuration for a source chain.
@@ -27,7 +26,6 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
         address[] optionalCCVs;
         uint64 sourceChainSelector;
         uint8 optionalThreshold;
-        bool requireFinality;
     }
 
     error DuplicateCCV(uint64 sourceChainSelector, address ccv);
@@ -35,18 +33,25 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
     error ZeroAddressNotAllowedAsOptional();
 
     event CCVConfigSet(
-        uint64 indexed sourceChainSelector,
-        address[] requiredCCVs,
-        address[] optionalCCVs,
-        uint8 optionalThreshold,
-        bool requireFinality
+        uint64 indexed sourceChainSelector, address[] requiredCCVs, address[] optionalCCVs, uint8 optionalThreshold
     );
+    event MinBlockDepthSet(uint64 indexed sourceChainSelector, uint16 minBlockDepth);
 
     mapping(uint64 sourceChainSelector => CCVConfig ccvConfig) internal s_ccvConfigs;
+    mapping(uint64 sourceChainSelector => uint16 minBlockDepth) internal s_minBlockDepths;
 
     constructor(address router) BasicMessageReceiver(router) Ownable(msg.sender) {}
 
-    /// @dev Override getCCVs
+    /// @notice Set minimum accepted block depth for a source chain.
+    /// @dev 0 means Default Finality is required for that source chain.
+    ///      Non-zero values allow Faster Than Finality with a minimum required depth - WARNING only use Faster Than Finality
+    ///      when you use a trusted sender on the source chain that manages the finality risk when sending messages.
+    function setMinBlockDepth(uint64 sourceChainSelector, uint16 minBlockDepth) external onlyOwner {
+        s_minBlockDepths[sourceChainSelector] = minBlockDepth;
+        emit MinBlockDepthSet(sourceChainSelector, minBlockDepth);
+    }
+
+    /// @dev Override getCCVsAndMinBlockDepth
     function getCCVsAndMinBlockDepth(
         uint64 sourceChainSelector,
         bytes calldata /*sender*/
@@ -62,11 +67,8 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
         )
     {
         CCVConfig memory config = s_ccvConfigs[sourceChainSelector];
-        // If requireFinality is true, minBlockDepth = 0 (require finality).
-        // If requireFinality is false, minBlockDepth = 1 (allow any FTF level) - WARNING only use a finality of 1 when
-        // you use a trusted sender on the source chain that manages the finality risk when sending messages.
-        minBlockDepth = config.requireFinality ? 0 : 1;
-        return (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, minBlockDepth);
+        return
+            (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, s_minBlockDepths[sourceChainSelector]);
     }
 
     /// @notice Set CCV configurations for source chains.
@@ -109,16 +111,9 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
             s_ccvConfigs[args.sourceChainSelector] = CCVConfig({
                 requiredCCVs: args.requiredCCVs,
                 optionalCCVs: args.optionalCCVs,
-                optionalThreshold: args.optionalThreshold,
-                requireFinality: args.requireFinality
+                optionalThreshold: args.optionalThreshold
             });
-            emit CCVConfigSet(
-                args.sourceChainSelector,
-                args.requiredCCVs,
-                args.optionalCCVs,
-                args.optionalThreshold,
-                args.requireFinality
-            );
+            emit CCVConfigSet(args.sourceChainSelector, args.requiredCCVs, args.optionalCCVs, args.optionalThreshold);
         }
     }
 }

--- a/contracts/BasicMessageReceiverWithCCVs.sol
+++ b/contracts/BasicMessageReceiverWithCCVs.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 import {BasicMessageReceiver} from "./BasicMessageReceiver.sol";
 
+import {FinalityCodec} from "@chainlink/contracts-ccip/contracts/libraries/FinalityCodec.sol";
 import {Ownable, Ownable2Step} from "@openzeppelin/contracts@5.3.0/access/Ownable2Step.sol";
 
 /**
@@ -51,8 +52,9 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
         emit MinBlockDepthSet(sourceChainSelector, minBlockDepth);
     }
 
-    /// @dev Override getCCVsAndMinBlockDepth
-    function getCCVsAndMinBlockDepth(
+    /// @notice Returns CCV config and allowed finality for a source chain (see `CCIPReceiver.getCCVsAndFinalityConfig`).
+    /// @dev Maps stored min block depth to `FinalityCodec` encoding (0 depth => wait for full finality).
+    function getCCVsAndFinalityConfig(
         uint64 sourceChainSelector,
         bytes calldata /*sender*/
     )
@@ -63,12 +65,13 @@ contract BasicMessageReceiverWithCCVs is BasicMessageReceiver, Ownable2Step {
             address[] memory requiredCCVs,
             address[] memory optionalCCVs,
             uint8 optionalThreshold,
-            uint16 minBlockDepth
+            bytes4 allowedFinalityConfig
         )
     {
         CCVConfig memory config = s_ccvConfigs[sourceChainSelector];
-        return
-            (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, s_minBlockDepths[sourceChainSelector]);
+        uint16 minBlockDepth = s_minBlockDepths[sourceChainSelector];
+        allowedFinalityConfig = FinalityCodec._encodeBlockDepth(minBlockDepth);
+        return (config.requiredCCVs, config.optionalCCVs, config.optionalThreshold, allowedFinalityConfig);
     }
 
     /// @notice Set CCV configurations for source chains.

--- a/contracts/utils/EncodeExtraArgsOffchain.sol
+++ b/contracts/utils/EncodeExtraArgsOffchain.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.26;
 
 import {Client} from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 import {ExtraArgsCodec} from "@chainlink/contracts-ccip/contracts/libraries/ExtraArgsCodec.sol";
+import {FinalityCodec} from "@chainlink/contracts-ccip/contracts/libraries/FinalityCodec.sol";
 
 /**
  * THIS IS AN EXAMPLE CONTRACT THAT USES HARDCODED VALUES FOR CLARITY.
@@ -79,7 +80,7 @@ contract EncodeExtraArgsOffchain {
     ) public pure returns (bytes memory extraArgsBytes) {
         ExtraArgsCodec.GenericExtraArgsV3 memory extraArgs = ExtraArgsCodec.GenericExtraArgsV3({
             gasLimit: gasLimit,
-            blockConfirmations: blockConfirmations,
+            requestedFinalityConfig: FinalityCodec._encodeBlockDepth(blockConfirmations),
             ccvs: ccvs,
             ccvArgs: ccvArgs,
             executor: executor,
@@ -97,7 +98,8 @@ contract EncodeExtraArgsOffchain {
         pure
         returns (bytes memory extraArgsBytes)
     {
-        extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, blockConfirmations);
+        bytes4 finalityConfig = FinalityCodec._encodeBlockDepth(blockConfirmations);
+        extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, finalityConfig);
     }
 
     /// @notice Get the NO_EXECUTION_ADDRESS for manual execution.

--- a/contracts/utils/EncodeExtraArgsOffchain.sol
+++ b/contracts/utils/EncodeExtraArgsOffchain.sol
@@ -102,6 +102,13 @@ contract EncodeExtraArgsOffchain {
         extraArgsBytes = ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, finalityConfig);
     }
 
+    /// @notice Returns `FinalityCodec._encodeBlockDepthAndSafeFlag(blockDepth)` — **wait-for-safe** plus optional depth in the lower 16 bits.
+    /// @dev Per `FinalityCodec`, this encoding is for **allowed** finality (e.g. token pool `setAllowedFinalityConfig`, receiver policy),
+    ///      not for **requested** `requestedFinalityConfig` in sender ExtraArgsV3 (requested finality must be a single mode).
+    function encodeAllowedFinalityBlockDepthAndSafeFlag(uint16 blockDepth) public pure returns (bytes4) {
+        return FinalityCodec._encodeBlockDepthAndSafeFlag(blockDepth);
+    }
+
     /// @notice Get the NO_EXECUTION_ADDRESS for manual execution.
     /// @return The address that signals no automatic execution.
     function getNoExecutionAddress() public pure returns (address) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       "@chainlink/contracts-ccip/contracts/Router.sol",
       "@chainlink/contracts-ccip/contracts/onRamp/OnRamp.sol",
       "@openzeppelin/contracts-5.3.0/token/ERC20/ERC20.sol",
-      "@chainlink/contracts-ccip/contracts/tokenAdminRegistry/TokenPoolFactory/FactoryBurnMintERC20.sol",
+      "@chainlink/contracts-ccip/contracts/tokens/CrossChainToken.sol",
       "@chainlink/contracts-ccip/contracts/pools/BurnMintTokenPool.sol",
       "@chainlink/contracts-ccip/contracts/pools/AdvancedPoolHooks.sol",
       "@chainlink/contracts-ccip/contracts/tokenAdminRegistry/RegistryModuleOwnerCustom.sol",

--- a/ignition/modules/BasicMessageReceiverWithCCVs.ts
+++ b/ignition/modules/BasicMessageReceiverWithCCVs.ts
@@ -1,0 +1,15 @@
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
+
+/*
+ * Deploy BasicMessageReceiverWithCCVs (Sepolia):
+ *   npx hardhat ignition deploy ignition/modules/BasicMessageReceiverWithCCVs.ts --network sepolia --parameters ignition/paramsEthSepolia.json
+ * Deploy (Fuji):
+ *   npx hardhat ignition deploy ignition/modules/BasicMessageReceiverWithCCVs.ts --network fuji --parameters ignition/paramsFuji.json
+ */
+
+export default buildModule("BasicMessageReceiverWithCCVsModule", (m) => {
+  const routerAddress = m.getParameter("routerAddress");
+  const basicMessageReceiverWithCCVs = m.contract("BasicMessageReceiverWithCCVs", [routerAddress]);
+
+  return { basicMessageReceiverWithCCVs };
+});

--- a/ignition/modules/BurnMintTokenPool.ts
+++ b/ignition/modules/BurnMintTokenPool.ts
@@ -14,23 +14,26 @@ const TOKEN_PREMINT = 1_000_000n * 10n ** 18n;
 const TOKEN_MAX_SUPPLY = 100_000_000n * 10n ** 18n;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-const FactoryBurnMintERC20Module = buildModule("FactoryBurnMintERC20Module", (m) => {
-  const newOwner = m.getAccount(0);
+const CrossChainTokenModule = buildModule("CrossChainTokenModule", (m) => {
+  const broadcaster = m.getAccount(0);
 
-  const factoryBurnMintERC20 = m.contract("FactoryBurnMintERC20", [
+  const tokenParams = [
     TOKEN_NAME,
     TOKEN_SYMBOL,
-    TOKEN_DECIMALS,
     TOKEN_MAX_SUPPLY,
     TOKEN_PREMINT,
-    newOwner,
-  ]);
+    broadcaster,
+    TOKEN_DECIMALS,
+    broadcaster,
+  ] as const;
 
-  return { factoryBurnMintERC20 };
+  const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
+
+  return { crossChainToken };
 });
 
 const BurnMintTokenPoolModule = buildModule("BurnMintTokenPoolModule", (m) => {
-  const { factoryBurnMintERC20 } = m.useModule(FactoryBurnMintERC20Module);
+  const { crossChainToken } = m.useModule(CrossChainTokenModule);
 
   const router = m.getParameter("routerAddress");
   const armProxy = m.getParameter("armProxy");
@@ -38,31 +41,30 @@ const BurnMintTokenPoolModule = buildModule("BurnMintTokenPoolModule", (m) => {
   const tokenAdminRegistryAddress = m.getParameter("tokenAdminRegistry");
 
   const burnMintTokenPool = m.contract("BurnMintTokenPool", [
-    factoryBurnMintERC20,
+    crossChainToken,
     TOKEN_DECIMALS,
-    ZERO_ADDRESS, // No advanced pool hook in CCT 02
+    ZERO_ADDRESS, // No advanced pool hook in CCT 01
     armProxy,
     router,
   ]);
 
-  m.call(factoryBurnMintERC20, "grantMintAndBurnRoles", [burnMintTokenPool]);
+  m.call(crossChainToken, "grantMintAndBurnRoles", [burnMintTokenPool]);
 
   const registryModuleOwnerCustom = m.contractAt("RegistryModuleOwnerCustom", registryModuleOwnerCustomAddress);
 
-  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaOwner", [factoryBurnMintERC20]);
+  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaGetCCIPAdmin", [crossChainToken]);
 
   const tokenAdminRegistry = m.contractAt("ITokenAdminRegistry", tokenAdminRegistryAddress);
 
-  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [factoryBurnMintERC20], {
+  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [crossChainToken], {
     after: [registerAdminCall],
   });
-  
-  m.call(tokenAdminRegistry, "setPool", [factoryBurnMintERC20, burnMintTokenPool], {
+
+  m.call(tokenAdminRegistry, "setPool", [crossChainToken, burnMintTokenPool], {
     after: [acceptAdminRoleCall],
   });
 
-
-  return { factoryBurnMintERC20, burnMintTokenPool };
+  return { crossChainToken, burnMintTokenPool };
 });
 
 export default BurnMintTokenPoolModule;

--- a/ignition/modules/BurnMintTokenPool.ts
+++ b/ignition/modules/BurnMintTokenPool.ts
@@ -17,15 +17,15 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const CrossChainTokenModule = buildModule("CrossChainTokenModule", (m) => {
   const broadcaster = m.getAccount(0);
 
-  const tokenParams = [
-    TOKEN_NAME,
-    TOKEN_SYMBOL,
-    TOKEN_MAX_SUPPLY,
-    TOKEN_PREMINT,
-    broadcaster,
-    TOKEN_DECIMALS,
-    broadcaster,
-  ] as const;
+  const tokenParams = {
+    name: TOKEN_NAME,
+    symbol: TOKEN_SYMBOL,
+    maxSupply: TOKEN_MAX_SUPPLY,
+    preMint: TOKEN_PREMINT,
+    preMintRecipient: broadcaster,
+    decimals: TOKEN_DECIMALS,
+    ccipAdmin: broadcaster,
+  };
 
   const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
 

--- a/ignition/modules/BurnMintTokenPoolAdvancedPoolHook.ts
+++ b/ignition/modules/BurnMintTokenPoolAdvancedPoolHook.ts
@@ -21,15 +21,15 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const CrossChainTokenAdvancedHookModule = buildModule("CrossChainTokenAdvancedHookModule", (m) => {
   const broadcaster = m.getAccount(0);
 
-  const tokenParams = [
-    TOKEN_NAME,
-    TOKEN_SYMBOL,
-    TOKEN_MAX_SUPPLY,
-    TOKEN_PREMINT,
-    broadcaster,
-    TOKEN_DECIMALS,
-    broadcaster,
-  ] as const;
+  const tokenParams = {
+    name: TOKEN_NAME,
+    symbol: TOKEN_SYMBOL,
+    maxSupply: TOKEN_MAX_SUPPLY,
+    preMint: TOKEN_PREMINT,
+    preMintRecipient: broadcaster,
+    decimals: TOKEN_DECIMALS,
+    ccipAdmin: broadcaster,
+  };
 
   const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
 

--- a/ignition/modules/BurnMintTokenPoolAdvancedPoolHook.ts
+++ b/ignition/modules/BurnMintTokenPoolAdvancedPoolHook.ts
@@ -1,7 +1,7 @@
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 
 /*
- * Example08 (CCT 03): Deploy BurnMint token + AdvancedPoolHooks + BurnMint pool.
+ * Example08 (CCT 03): Deploy CrossChainToken + AdvancedPoolHooks + BurnMint pool.
  * Params: routerAddress, armProxy, registryModuleOwnerCustom, tokenAdminRegistry, thresholdAmountForAdditionalCCVs.
  *
  * Deploy (Sepolia):
@@ -18,23 +18,26 @@ const TOKEN_MAX_SUPPLY = 100_000_000n * 10n ** 18n;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Distinct token module so we deploy a new token (avoids AlreadyRegistered).
-const FactoryBurnMintERC20AdvancedHookModule = buildModule("FactoryBurnMintERC20AdvancedHookModule", (m) => {
-  const newOwner = m.getAccount(0);
+const CrossChainTokenAdvancedHookModule = buildModule("CrossChainTokenAdvancedHookModule", (m) => {
+  const broadcaster = m.getAccount(0);
 
-  const factoryBurnMintERC20 = m.contract("FactoryBurnMintERC20", [
+  const tokenParams = [
     TOKEN_NAME,
     TOKEN_SYMBOL,
-    TOKEN_DECIMALS,
     TOKEN_MAX_SUPPLY,
     TOKEN_PREMINT,
-    newOwner,
-  ]);
+    broadcaster,
+    TOKEN_DECIMALS,
+    broadcaster,
+  ] as const;
 
-  return { factoryBurnMintERC20 };
+  const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
+
+  return { crossChainToken };
 });
 
 const BurnMintTokenPoolAdvancedPoolHookModule = buildModule("BurnMintTokenPoolAdvancedPoolHookModule", (m) => {
-  const { factoryBurnMintERC20 } = m.useModule(FactoryBurnMintERC20AdvancedHookModule);
+  const { crossChainToken } = m.useModule(CrossChainTokenAdvancedHookModule);
   const broadcaster = m.getAccount(0);
 
   const router = m.getParameter("routerAddress");
@@ -53,7 +56,7 @@ const BurnMintTokenPoolAdvancedPoolHookModule = buildModule("BurnMintTokenPoolAd
   ]);
 
   const burnMintTokenPool = m.contract("BurnMintTokenPool", [
-    factoryBurnMintERC20,
+    crossChainToken,
     TOKEN_DECIMALS,
     advancedPoolHooks,
     armProxy,
@@ -64,23 +67,23 @@ const BurnMintTokenPoolAdvancedPoolHookModule = buildModule("BurnMintTokenPoolAd
     { addedCallers: [burnMintTokenPool], removedCallers: [] },
   ]);
 
-  m.call(factoryBurnMintERC20, "grantMintAndBurnRoles", [burnMintTokenPool]);
+  m.call(crossChainToken, "grantMintAndBurnRoles", [burnMintTokenPool]);
 
   const registryModuleOwnerCustom = m.contractAt("RegistryModuleOwnerCustom", registryModuleOwnerCustomAddress);
 
-  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaOwner", [factoryBurnMintERC20]);
+  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaGetCCIPAdmin", [crossChainToken]);
 
   const tokenAdminRegistry = m.contractAt("ITokenAdminRegistry", tokenAdminRegistryAddress);
 
-  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [factoryBurnMintERC20], {
+  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [crossChainToken], {
     after: [registerAdminCall],
   });
 
-  m.call(tokenAdminRegistry, "setPool", [factoryBurnMintERC20, burnMintTokenPool], {
+  m.call(tokenAdminRegistry, "setPool", [crossChainToken, burnMintTokenPool], {
     after: [acceptAdminRoleCall],
   });
 
-  return { factoryBurnMintERC20, advancedPoolHooks, burnMintTokenPool };
+  return { crossChainToken, advancedPoolHooks, burnMintTokenPool };
 });
 
 export default BurnMintTokenPoolAdvancedPoolHookModule;

--- a/ignition/modules/LockAndReleaseTokenPool.ts
+++ b/ignition/modules/LockAndReleaseTokenPool.ts
@@ -22,15 +22,15 @@ const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const CrossChainTokenLockReleaseModule = buildModule("CrossChainTokenLockReleaseModule", (m) => {
   const broadcaster = m.getAccount(0);
 
-  const tokenParams = [
-    TOKEN_NAME,
-    TOKEN_SYMBOL,
-    TOKEN_MAX_SUPPLY,
-    TOKEN_PREMINT,
-    broadcaster,
-    TOKEN_DECIMALS,
-    broadcaster,
-  ] as const;
+  const tokenParams = {
+    name: TOKEN_NAME,
+    symbol: TOKEN_SYMBOL,
+    maxSupply: TOKEN_MAX_SUPPLY,
+    preMint: TOKEN_PREMINT,
+    preMintRecipient: broadcaster,
+    decimals: TOKEN_DECIMALS,
+    ccipAdmin: broadcaster,
+  };
 
   const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
 

--- a/ignition/modules/LockAndReleaseTokenPool.ts
+++ b/ignition/modules/LockAndReleaseTokenPool.ts
@@ -18,34 +18,37 @@ const TOKEN_MAX_SUPPLY = 100_000_000n * 10n ** 18n;
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 // Use a distinct name so Ignition deploys a new token for Lock Release instead of reusing
-// the token from BurnMintTokenPoolModule (which would cause AlreadyRegistered on registerAdminViaOwner).
-const FactoryBurnMintERC20LockReleaseModule = buildModule("FactoryBurnMintERC20LockReleaseModule", (m) => {
-  const newOwner = m.getAccount(0);
+// the token from BurnMintTokenPoolModule (which would cause AlreadyRegistered on registerAdminViaGetCCIPAdmin).
+const CrossChainTokenLockReleaseModule = buildModule("CrossChainTokenLockReleaseModule", (m) => {
+  const broadcaster = m.getAccount(0);
 
-  const factoryBurnMintERC20 = m.contract("FactoryBurnMintERC20", [
+  const tokenParams = [
     TOKEN_NAME,
     TOKEN_SYMBOL,
-    TOKEN_DECIMALS,
     TOKEN_MAX_SUPPLY,
     TOKEN_PREMINT,
-    newOwner,
-  ]);
+    broadcaster,
+    TOKEN_DECIMALS,
+    broadcaster,
+  ] as const;
 
-  return { factoryBurnMintERC20 };
+  const crossChainToken = m.contract("CrossChainToken", [tokenParams, broadcaster, broadcaster]);
+
+  return { crossChainToken };
 });
 
 const LockAndReleaseTokenPoolModule = buildModule("LockAndReleaseTokenPoolModule", (m) => {
-  const { factoryBurnMintERC20 } = m.useModule(FactoryBurnMintERC20LockReleaseModule);
+  const { crossChainToken } = m.useModule(CrossChainTokenLockReleaseModule);
 
   const router = m.getParameter("routerAddress");
   const armProxy = m.getParameter("armProxy");
   const registryModuleOwnerCustomAddress = m.getParameter("registryModuleOwnerCustom");
   const tokenAdminRegistryAddress = m.getParameter("tokenAdminRegistry");
 
-  const erc20LockBox = m.contract("ERC20LockBox", [factoryBurnMintERC20]);
+  const erc20LockBox = m.contract("ERC20LockBox", [crossChainToken]);
 
   const lockReleaseTokenPool = m.contract("LockReleaseTokenPool", [
-    factoryBurnMintERC20,
+    crossChainToken,
     TOKEN_DECIMALS,
     ZERO_ADDRESS, // No advanced pool hook in CCT 02
     armProxy,
@@ -59,19 +62,19 @@ const LockAndReleaseTokenPoolModule = buildModule("LockAndReleaseTokenPoolModule
 
   const registryModuleOwnerCustom = m.contractAt("RegistryModuleOwnerCustom", registryModuleOwnerCustomAddress);
 
-  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaOwner", [factoryBurnMintERC20]);
+  const registerAdminCall = m.call(registryModuleOwnerCustom, "registerAdminViaGetCCIPAdmin", [crossChainToken]);
 
   const tokenAdminRegistry = m.contractAt("ITokenAdminRegistry", tokenAdminRegistryAddress);
 
-  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [factoryBurnMintERC20], {
+  const acceptAdminRoleCall = m.call(tokenAdminRegistry, "acceptAdminRole", [crossChainToken], {
     after: [registerAdminCall],
   });
 
-  m.call(tokenAdminRegistry, "setPool", [factoryBurnMintERC20, lockReleaseTokenPool], {
+  m.call(tokenAdminRegistry, "setPool", [crossChainToken, lockReleaseTokenPool], {
     after: [acceptAdminRoleCall],
   });
 
-  return { factoryBurnMintERC20, erc20LockBox, lockReleaseTokenPool };
+  return { crossChainToken, erc20LockBox, lockReleaseTokenPool };
 });
 
 export default LockAndReleaseTokenPoolModule;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@chainlink/contracts": "^1.5.0",
-        "@chainlink/contracts-ccip": "file:libs/chainlink-ccip/chains/evm",
+        "@chainlink/contracts-ccip": "^2.0.0-beta.0",
         "@openzeppelin/contracts-5.3.0": "npm:@openzeppelin/contracts@^5.3.0"
       },
       "devDependencies": {
@@ -25,46 +25,13 @@
     "5.3.0": {
       "extraneous": true
     },
-    "libs/chainlink-ccip/chains/evm": {
-      "name": "@chainlink/contracts-ccip",
-      "version": "1.6.4",
-      "license": "BUSL-1.1",
-      "dependencies": {
-        "@chainlink/ace": "1.0.0",
-        "@chainlink/contracts": "1.5.0",
-        "@openzeppelin/contracts-4.8.3": "npm:@openzeppelin/contracts@4.8.3",
-        "@openzeppelin/contracts-5.3.0": "npm:@openzeppelin/contracts@5.3.0",
-        "semver": "^7.7.3"
-      },
-      "devDependencies": {
-        "@changesets/cli": "^2.29.8",
-        "@changesets/get-github-info": "^0.7.0",
-        "semver": "^7.7.3",
-        "solhint": "^6.0.2",
-        "solhint-plugin-chainlink-solidity": "github:smartcontractkit/chainlink-solhint-rules#v1.2.1"
-      },
-      "engines": {
-        "node": ">=20",
-        "pnpm": ">=10"
-      }
-    },
-    "libs/chainlink-ccip/chains/evm/node_modules/@changesets/get-github-info": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.7.0.tgz",
-      "integrity": "sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
-      }
-    },
     "node_modules/@actions/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
       "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/exec": "^1.1.1",
         "@actions/http-client": "^2.0.1"
@@ -76,6 +43,7 @@
       "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/io": "^1.0.1"
       }
@@ -86,6 +54,7 @@
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tunnel": "^0.0.6",
         "undici": "^5.25.4"
@@ -96,7 +65,8 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
       "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
@@ -130,31 +100,6 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
       "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A==",
       "license": "MIT"
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
@@ -198,8 +143,21 @@
       }
     },
     "node_modules/@chainlink/contracts-ccip": {
-      "resolved": "libs/chainlink-ccip/chains/evm",
-      "link": true
+      "version": "2.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@chainlink/contracts-ccip/-/contracts-ccip-2.0.0-beta.0.tgz",
+      "integrity": "sha512-mmEJgqKNdDiRdUDHmxh8L7LJO80LHizvLnbXmoCKaWORJy5VEW5hriTtULZ5BcC/C/0RRSiKu8c2qdf2asr31Q==",
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "@chainlink/ace": "1.0.0",
+        "@chainlink/contracts": "1.5.0",
+        "@openzeppelin/contracts-4.8.3": "npm:@openzeppelin/contracts@4.8.3",
+        "@openzeppelin/contracts-5.3.0": "npm:@openzeppelin/contracts@5.3.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">=20",
+        "pnpm": ">=10"
+      }
     },
     "node_modules/@chainlink/contracts/node_modules/@eth-optimism/contracts": {
       "version": "0.6.0",
@@ -1255,6 +1213,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/basex": "^5.8.0",
@@ -1285,6 +1244,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
@@ -1305,7 +1265,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.8.0",
@@ -1377,6 +1338,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/sha2": "^5.8.0"
@@ -1560,6 +1522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -1632,6 +1595,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.8.0",
         "@ethersproject/constants": "^5.8.0",
@@ -1653,6 +1617,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/abstract-signer": "^5.8.0",
@@ -1709,6 +1674,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.8.0",
         "@ethersproject/hash": "^5.8.0",
@@ -1723,18 +1689,9 @@
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@humanwhocodes/momoa": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-2.0.4.tgz",
-      "integrity": "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.10.0"
       }
     },
     "node_modules/@inquirer/external-editor": {
@@ -1764,6 +1721,7 @@
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -1843,6 +1801,7 @@
       "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1882,6 +1841,7 @@
       "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2029,7 +1989,6 @@
       "integrity": "sha512-hLDQjkUIZ9tHrgXRsqn7ZFofWj6gf7SH6ImjetOZFy25uatKgnz78doCzrGs1gUCBnpKOP9Ck/5a88cK9xBESw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/hardhat-errors": "^3.0.7",
         "@nomicfoundation/hardhat-utils": "^4.0.0",
@@ -2106,6 +2065,7 @@
       "integrity": "sha512-lbbOVOVxHY+x3olztf8m19nuxpkx/6zN8dmGlbb1CA0V3QvN8EyQWl8O6xtxmTQhLTPKUGwA2r02ikE5Qa02dw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@actions/core": "^1.10.1",
         "chalk": "^5.3.0",
@@ -2260,7 +2220,6 @@
       "integrity": "sha512-IURCj/GJS7e8FgBeWe/pdpI3yQKccttUGkUZJLkgXaEdeENnXjnG8kUXIIgURGqB6NQuk9TXdI5DwAtrzkenCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ethersproject/address": "5.6.1",
         "@nomicfoundation/hardhat-errors": "^3.0.7",
@@ -2470,51 +2429,6 @@
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==",
       "license": "MIT"
     },
-    "node_modules/@pnpm/config.env-replace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
-      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.22.0"
-      }
-    },
-    "node_modules/@pnpm/network.ca-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
-      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "4.2.10"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      }
-    },
-    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@pnpm/npm-conf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pnpm/config.env-replace": "^1.1.0",
-        "@pnpm/network.ca-file": "^1.0.1",
-        "config-chain": "^1.1.11"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@scroll-tech/contracts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scroll-tech/contracts/-/contracts-2.0.0.tgz",
@@ -2601,27 +2515,8 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
-      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
-      "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@solidity-parser/parser": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.20.2.tgz",
-      "integrity": "sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA==",
-      "dev": true,
-      "license": "MIT"
+      "peer": true
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.22",
@@ -2640,33 +2535,12 @@
         "@streamparser/json": "^0.0.22"
       }
     },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2721,7 +2595,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2760,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2770,16 +2642,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": ">=5.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -2806,6 +2668,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2837,23 +2700,6 @@
         "node": "*"
       }
     },
-    "node_modules/ast-parents": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/ast-parents/-/ast-parents-0.0.1.tgz",
-      "integrity": "sha512-XHusKxKz3zoYk1ic8Un640joHbFMhbqneyoZfoKnEGtf2ey9Uh/IdpcQplODdO/kENaMIWsD0nJm4+wX3UNLHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -2874,59 +2720,6 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
       "license": "MIT"
-    },
-    "node_modules/better-ajv-errors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-2.0.3.tgz",
-      "integrity": "sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@humanwhocodes/momoa": "^2.0.4",
-        "chalk": "^4.1.2",
-        "jsonpointer": "^5.0.1",
-        "leven": "^3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">= 18.20.6"
-      },
-      "peerDependencies": {
-        "ajv": "4.11.8 - 8"
-      }
-    },
-    "node_modules/better-ajv-errors/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/better-ajv-errors/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
@@ -2981,35 +2774,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
-      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/cacheable-request": {
-      "version": "10.2.14",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
-      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/http-cache-semantics": "^4.0.2",
-        "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "keyv": "^4.5.3",
-        "mimic-response": "^4.0.0",
-        "normalize-url": "^8.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
       }
     },
     "node_modules/callsites": {
@@ -3129,59 +2893,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
-    },
-    "node_modules/config-chain": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0",
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/cross-spawn": {
       "version": "6.0.6",
@@ -3231,35 +2947,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3270,26 +2957,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/detect-indent": {
@@ -3307,6 +2974,7 @@
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3344,13 +3012,6 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/enquirer": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
@@ -3372,16 +3033,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/esbuild": {
@@ -3585,13 +3236,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/fast-equals": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
@@ -3623,23 +3267,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -3690,16 +3317,6 @@
       "dev": true,
       "license": "(Apache-2.0 OR MIT)"
     },
-    "node_modules/form-data-encoder": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
-      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.17"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -3742,19 +3359,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3835,32 +3439,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/got": {
-      "version": "12.6.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
-      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^5.2.0",
-        "@szmarczak/http-timer": "^5.0.1",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^10.2.8",
-        "decompress-response": "^6.0.0",
-        "form-data-encoder": "^2.1.2",
-        "get-stream": "^6.0.1",
-        "http2-wrapper": "^2.1.10",
-        "lowercase-keys": "^3.0.0",
-        "p-cancelable": "^3.0.0",
-        "responselike": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3873,7 +3451,6 @@
       "integrity": "sha512-+J3LmO5j3r8bYRIiImaTT6WtT0EKcR0nfFxWq/bokAKZq7GKYf6ErKSrOuH+gFIqo+CfnrkxcgbPY20P5vuuSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nomicfoundation/edr": "0.12.0-next.24",
         "@nomicfoundation/hardhat-errors": "^3.0.7",
@@ -3950,27 +3527,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/http-cache-semantics": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/http2-wrapper": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
-      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
       }
     },
     "node_modules/human-id": {
@@ -4060,20 +3616,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -4114,16 +3656,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4208,6 +3740,7 @@
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -4224,6 +3757,7 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4240,6 +3774,7 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4257,6 +3792,7 @@
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -4265,13 +3801,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
       "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4285,20 +3814,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -4345,26 +3860,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonpointer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
-      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
@@ -4384,39 +3879,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/latest-version": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
-      "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "package-json": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4428,13 +3890,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
@@ -4449,13 +3904,6 @@
       "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "license": "MIT"
     },
-    "node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -4463,19 +3911,6 @@
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -4562,19 +3997,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mimic-response": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
-      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -4669,19 +4091,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/normalize-url": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
-      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/once": {
@@ -4843,16 +4252,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/p-cancelable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
-      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/p-filter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
@@ -4923,25 +4322,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.1.tgz",
-      "integrity": "sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "got": "^12.1.0",
-        "registry-auth-token": "^5.0.1",
-        "registry-url": "^6.0.0",
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/package-manager-detector": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
@@ -4961,25 +4341,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/patch-package": {
@@ -5168,16 +4529,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pluralize": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
-      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/prettier": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
@@ -5199,6 +4550,7 @@
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -5221,13 +4573,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5274,51 +4619,13 @@
       ],
       "license": "MIT"
     },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
@@ -5386,52 +4693,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/registry-auth-token": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
-      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pnpm/npm-conf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/registry-url": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
-      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rc": "1.2.8"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-alpn": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -5459,22 +4720,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/responselike": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
-      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lowercase-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {
@@ -5561,7 +4806,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -5624,161 +4870,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/solady": {
       "version": "0.0.182",
       "resolved": "https://registry.npmjs.org/solady/-/solady-0.0.182.tgz",
       "integrity": "sha512-FW6xo1akJoYpkXMzu58/56FcNU3HYYNamEbnFO3iSibXk0nSHo0DV2Gu/zI3FPg3So5CCX6IYli1TT1IWATnvg==",
       "license": "MIT"
-    },
-    "node_modules/solhint": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-6.0.3.tgz",
-      "integrity": "sha512-LYiy1bN8X9eUsti13mbS4fY6ILVxhP6VoOgqbHxCsHl5VPnxOWf7U1V9ZvgizxdInKBMW82D1FNJO+daAcWHbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@solidity-parser/parser": "^0.20.2",
-        "ajv": "^6.12.6",
-        "ajv-errors": "^1.0.1",
-        "ast-parents": "^0.0.1",
-        "better-ajv-errors": "^2.0.2",
-        "chalk": "^4.1.2",
-        "commander": "^10.0.0",
-        "cosmiconfig": "^8.0.0",
-        "fast-diff": "^1.2.0",
-        "glob": "^8.0.3",
-        "ignore": "^5.2.4",
-        "js-yaml": "^4.1.0",
-        "latest-version": "^7.0.0",
-        "lodash": "^4.17.21",
-        "pluralize": "^8.0.0",
-        "semver": "^7.5.2",
-        "table": "^6.8.1",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "solhint": "solhint.js"
-      },
-      "optionalDependencies": {
-        "prettier": "^2.8.3"
-      }
-    },
-    "node_modules/solhint-plugin-chainlink-solidity": {
-      "name": "@chainlink/solhint-plugin-chainlink-solidity",
-      "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/smartcontractkit/chainlink-solhint-rules.git#1b4c0c2663fcd983589d4f33a2e73908624ed43c",
-      "dev": true
-    },
-    "node_modules/solhint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/solhint/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/solhint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/solhint/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/solhint/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/spawndamnit": {
       "version": "3.0.1",
@@ -5875,21 +4971,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -5935,47 +5016,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/table": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
-      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/table/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/table/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -5987,13 +5027,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -6068,6 +5101,7 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
@@ -6087,7 +5121,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6102,6 +5135,7 @@
       "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -6153,7 +5187,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -6303,7 +5336,6 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -6335,7 +5367,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "^1.5.0",
-    "@chainlink/contracts-ccip": "file:libs/chainlink-ccip/chains/evm",
+    "@chainlink/contracts-ccip": "^2.0.0-beta.0",
     "@openzeppelin/contracts-5.3.0": "npm:@openzeppelin/contracts@^5.3.0"
   }
 }

--- a/scripts/CallEncodeExtraArgsOffchain.ts
+++ b/scripts/CallEncodeExtraArgsOffchain.ts
@@ -50,8 +50,14 @@ const DEFAULT_ENCODE_V3 = {
 };
 
 export async function encodeV3Basic(params: EncodeV3Params) {
-  const v3Bytes = await encodeV3(params);
-  return v3Bytes;
+  const { publicClient, encoder } = await extraArgsContract();
+  const { gasLimit, blockConfirmations } = params;
+  return publicClient.readContract({
+    address: encoder.address,
+    abi: encoder.abi,
+    functionName: "encodeV3Basic",
+    args: [gasLimit, blockConfirmations],
+  });
 }
 
 export async function encodeV3(params: EncodeV3Params) {

--- a/scripts/CallEncodeExtraArgsOffchain.ts
+++ b/scripts/CallEncodeExtraArgsOffchain.ts
@@ -18,6 +18,7 @@
         Ideally, any new versions can be added by modifying  contracts/utils/EncodeExtraArgsOffchain.sol only
 */
 
+import type { Abi } from "viem";
 import { network } from "hardhat";
 
 export async function extraArgsContract() {
@@ -57,6 +58,17 @@ export async function encodeV3Basic(params: EncodeV3Params) {
     abi: encoder.abi,
     functionName: "encodeV3Basic",
     args: [gasLimit, blockConfirmations],
+  });
+}
+
+/** Allowed-finality helper: `FinalityCodec._encodeBlockDepthAndSafeFlag` — for pools/receivers, not sender ExtraArgs requestedFinality. */
+export async function encodeAllowedFinalityBlockDepthAndSafeFlag(blockDepth: number) {
+  const { publicClient, encoder } = await extraArgsContract();
+  return publicClient.readContract({
+    address: encoder.address,
+    abi: encoder.abi as Abi,
+    functionName: "encodeAllowedFinalityBlockDepthAndSafeFlag",
+    args: [BigInt(blockDepth)],
   });
 }
 

--- a/tasks/Example02.ts
+++ b/tasks/Example02.ts
@@ -1,6 +1,9 @@
 /**
  * Message-only CCIP send (no tokens).
  *
+ * For `BasicMessageReceiverWithCCVs`, deploy with Ignition and configure min block depth on the destination chain
+ * (`set-basic-message-receiver-with-ccvs-min-block-depth`) before sending with `--block-confirmations > 0`.
+ *
  * Command to run:
  *   npx hardhat example02 --network <NETWORK_NAME> --source-router <SOURCE_ROUTER> --destination-chain-selector <DESTINATION_CHAIN_SELECTOR> --receiver <RECEIVER> --message-text <MESSAGE_TEXT> [--gas-limit 200000] [--block-confirmations 1] [--fee-token-address <FEE_TOKEN_ADDRESS>]
  */
@@ -78,6 +81,9 @@ export default async function example02Step2Action(
 
   const chainId = publicClient.chain?.id ?? 0n;
   console.log("[INFO] Example02: Hello World data message + Faster Than Finality (EOA sender)");
+  console.log(
+    "[INFO] If the receiver is BasicMessageReceiverWithCCVs, default min block depth is 0 (finality-only) until you configure it per source chain (set-basic-message-receiver-with-ccvs-min-block-depth)."
+  );
   console.log("[INFO] Source chain ID:", chainId.toString());
   console.log("[INFO] Source router:", sourceRouter);
   console.log("[INFO] Destination selector:", destinationChainSelector.toString());
@@ -87,6 +93,11 @@ export default async function example02Step2Action(
   console.log("[INFO] Fee token:", feeTokenAddress);
   console.log("[WARN] Executor may enforce a minimum block confirmation value and revert if too low.");
   console.log("[WARN] If requested confirmations exceed chain finality, default finality is used.");
+  if (blockConfirmations > 0) {
+    console.log(
+      "[INFO] --block-confirmations should be >= the receiver's minBlockDepth for that source chain (BasicMessageReceiverWithCCVs)."
+    );
+  }
 
   const params: EncodeV3Params = { gasLimit, blockConfirmations };
   const extraArgs = await encodeV3Basic(params);

--- a/tasks/hardhat.tasks.ts
+++ b/tasks/hardhat.tasks.ts
@@ -218,6 +218,31 @@ const executorMinBlockConfirmationsTask = task(
   .setAction(() => import("./helpers/ExecutorMinBlockConfirmations.js"))
   .build();
 
+const setBasicMessageReceiverWithCCVsMinBlockDepthTask = task(
+  "set-basic-message-receiver-with-ccvs-min-block-depth",
+  "Set BasicMessageReceiverWithCCVs.setMinBlockDepth for a source chain (run on destination network)."
+)
+  .addOption({
+    name: "receiver",
+    description: "Deployed BasicMessageReceiverWithCCVs address",
+    type: ArgumentType.STRING,
+    defaultValue: "",
+  })
+  .addOption({
+    name: "sourceChainSelector",
+    description: "Source chain selector (uint64)",
+    type: ArgumentType.BIGINT,
+    defaultValue: 0n,
+  })
+  .addOption({
+    name: "minBlockDepth",
+    description: "Minimum block depth (uint16); 0 = default finality only for that source",
+    type: ArgumentType.INT,
+    defaultValue: 0,
+  })
+  .setAction(() => import("./helpers/SetBasicMessageReceiverWithCCVsMinBlockDepth.js"))
+  .build();
+
 const basicMessageReceiverLatestMessageTask = task(
   "basic-message-receiver-latest-message",
   "Read BasicMessageReceiver.latestMessage() (bytes). Decodes to string when possible."
@@ -328,6 +353,7 @@ const legacy02Task = task("legacy02", "Legacy02: ExtraArgs V2 token transfer.")
 export const tasks = [
   faucetTask,
   executorMinBlockConfirmationsTask,
+  setBasicMessageReceiverWithCCVsMinBlockDepthTask,
   basicMessageReceiverLatestMessageTask,
   basicMessageReceiverLatestSenderTask,
   basicMessageReceiverLatestSourceChainSelectorTask,

--- a/tasks/hardhat.tasks.ts
+++ b/tasks/hardhat.tasks.ts
@@ -205,9 +205,9 @@ const faucetTask = task(
   .setAction(() => import("./helpers/Faucet.js"))
   .build();
 
-const executorMinBlockConfirmationsTask = task(
-  "executor-min-block-confirmations",
-  "Read Executor.getMinBlockConfirmations() (uint16). Use before picking block depth for Faster Than Finality."
+const executorAllowedFinalityConfigTask = task(
+  "executor-allowed-finality-config",
+  "Read Executor.getAllowedFinalityConfig() (bytes4, FinalityCodec). Use when aligning FTF with executor policy."
 )
   .addOption({
     name: "executor",
@@ -215,7 +215,7 @@ const executorMinBlockConfirmationsTask = task(
     type: ArgumentType.STRING,
     defaultValue: "",
   })
-  .setAction(() => import("./helpers/ExecutorMinBlockConfirmations.js"))
+  .setAction(() => import("./helpers/ExecutorAllowedFinalityConfig.js"))
   .build();
 
 const setBasicMessageReceiverWithCCVsMinBlockDepthTask = task(
@@ -352,7 +352,7 @@ const legacy02Task = task("legacy02", "Legacy02: ExtraArgs V2 token transfer.")
 /** All Hardhat tasks. Import this array in hardhat.config.ts. */
 export const tasks = [
   faucetTask,
-  executorMinBlockConfirmationsTask,
+  executorAllowedFinalityConfigTask,
   setBasicMessageReceiverWithCCVsMinBlockDepthTask,
   basicMessageReceiverLatestMessageTask,
   basicMessageReceiverLatestSenderTask,

--- a/tasks/helpers/ExecutorAllowedFinalityConfig.ts
+++ b/tasks/helpers/ExecutorAllowedFinalityConfig.ts
@@ -1,13 +1,13 @@
 /**
- * Read Executor.getMinBlockConfirmations() (uint16). Use before picking block depth for Faster Than Finality.
+ * Read Executor.getAllowedFinalityConfig() (bytes4, FinalityCodec). Use when tuning Faster Than Finality vs default finality.
  *
  * Command to run:
- *   npx hardhat executor-min-block-confirmations --network <NETWORK_NAME> --executor <EXECUTOR_ADDRESS>
+ *   npx hardhat executor-allowed-finality-config --network <NETWORK_NAME> --executor <EXECUTOR_ADDRESS>
  */
 
 import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
 
-export interface ExecutorMinBlockConfirmationsTaskArguments {
+export interface ExecutorAllowedFinalityConfigTaskArguments {
   executor: string;
 }
 
@@ -17,8 +17,8 @@ function toAddress(s: string): `0x${string}` {
 
 const ZERO = "0x0000000000000000000000000000000000000000" as `0x${string}`;
 
-export default async function executorMinBlockConfirmationsAction(
-  taskArguments: ExecutorMinBlockConfirmationsTaskArguments,
+export default async function executorAllowedFinalityConfigAction(
+  taskArguments: ExecutorAllowedFinalityConfigTaskArguments,
   hre: HardhatRuntimeEnvironment
 ): Promise<void> {
   const { executor: executorStr } = taskArguments;
@@ -33,11 +33,11 @@ export default async function executorMinBlockConfirmationsAction(
   const publicClient = await connection.viem.getPublicClient();
   if (!publicClient) throw new Error("No public client");
 
-  const minBlockConfirmations = (await publicClient.readContract({
+  const allowedFinalityConfig = (await publicClient.readContract({
     address: executor,
     abi: artifact.abi,
-    functionName: "getMinBlockConfirmations",
-  })) as number;
+    functionName: "getAllowedFinalityConfig",
+  })) as `0x${string}`;
 
-  console.log("Min block confirmations", minBlockConfirmations);
+  console.log("Allowed finality config (bytes4)", allowedFinalityConfig);
 }

--- a/tasks/helpers/SetBasicMessageReceiverWithCCVsMinBlockDepth.ts
+++ b/tasks/helpers/SetBasicMessageReceiverWithCCVsMinBlockDepth.ts
@@ -1,0 +1,56 @@
+/**
+ * Set BasicMessageReceiverWithCCVs.setMinBlockDepth(sourceChainSelector, minBlockDepth) on the destination chain.
+ *
+ * Command to run:
+ *   npx hardhat set-basic-message-receiver-with-ccvs-min-block-depth --network <NETWORK_NAME> --receiver <RECEIVER> --source-chain-selector <SOURCE_CHAIN_SELECTOR> --min-block-depth <MIN_BLOCK_DEPTH>
+ */
+
+import type { HardhatRuntimeEnvironment } from "hardhat/types/hre";
+import type { Abi } from "viem";
+
+export interface SetBasicMessageReceiverWithCCVsMinBlockDepthTaskArguments {
+  receiver: string;
+  sourceChainSelector: bigint;
+  minBlockDepth: number;
+}
+
+function toAddress(s: string): `0x${string}` {
+  return (s.startsWith("0x") ? s : `0x${s}`) as `0x${string}`;
+}
+
+const ZERO = "0x0000000000000000000000000000000000000000" as `0x${string}`;
+
+export default async function setBasicMessageReceiverWithCCVsMinBlockDepthAction(
+  taskArguments: SetBasicMessageReceiverWithCCVsMinBlockDepthTaskArguments,
+  hre: HardhatRuntimeEnvironment
+): Promise<void> {
+  const { receiver: receiverStr, sourceChainSelector, minBlockDepth } = taskArguments;
+  const receiver = toAddress(receiverStr);
+
+  if (!receiverStr?.trim() || receiver === ZERO) {
+    throw new Error("receiver (BasicMessageReceiverWithCCVs contract address) is required.");
+  }
+  if (sourceChainSelector === 0n) {
+    throw new Error("sourceChainSelector cannot be zero.");
+  }
+  if (minBlockDepth < 0 || minBlockDepth > 65535) {
+    throw new Error("minBlockDepth must be between 0 and 65535 (uint16).");
+  }
+
+  const artifact = await hre.artifacts.readArtifact("BasicMessageReceiverWithCCVs");
+  const connection = await hre.network.connect();
+  const walletClient = (await connection.viem.getWalletClients())[0];
+  if (!walletClient?.account) throw new Error("No wallet client");
+
+  const hash = await walletClient.writeContract({
+    address: receiver,
+    abi: artifact.abi as Abi,
+    functionName: "setMinBlockDepth",
+    args: [sourceChainSelector, minBlockDepth],
+    account: walletClient.account,
+  });
+
+  console.log("[RESULT] BasicMessageReceiverWithCCVs source chain selector:", sourceChainSelector.toString());
+  console.log("[RESULT] BasicMessageReceiverWithCCVs min block depth:", minBlockDepth);
+  console.log("[RESULT] Transaction hash:", hash);
+}


### PR DESCRIPTION
## Summary

Updates the **Hardhat 3** CCIP starter kit to **`@chainlink/contracts-ccip` 2.0 beta** and aligns examples with current CCIP contracts: **CrossChainToken** for CCT Ignition deployments, **FinalityCodec**-based **ExtraArgs V3** encoding, **`getCCVsAndFinalityConfig`** on the sample receiver, and **`Executor.getAllowedFinalityConfig()`** for the optional executor check (replacing **`getMinBlockConfirmations()`**).

## What’s in this PR

### Dependency

- Bump **`@chainlink/contracts-ccip`** to the **2.0 beta** line so **`CrossChainToken`**, **`FinalityCodec`**, and updated **Executor** / **TokenPool** ABIs are available to Hardhat’s **`npmFilesToBuild`** and TS helpers.

### Contracts

- **`contracts/utils/EncodeExtraArgsOffchain.sol`:** V3 uses **`requestedFinalityConfig`**; **`encodeV3Basic`** uses **`FinalityCodec._encodeBlockDepth`** + **`ExtraArgsCodec._getBasicEncodedExtraArgsV3(gasLimit, finalityConfig)`**.
- **`contracts/BasicMessageReceiverWithCCVs.sol`:** Implements **`getCCVsAndFinalityConfig`**, mapping stored per-chain min depth to **`allowedFinalityConfig`** via **`FinalityCodec._encodeBlockDepth`**.

### Hardhat config

- **`hardhat.config.ts`:** Build **`@chainlink/contracts-ccip/.../tokens/CrossChainToken.sol`** instead of **`FactoryBurnMintERC20.sol`**.

### Ignition (CCT Examples 6–8)

- **`ignition/modules/BurnMintTokenPool.ts`**, **`BurnMintTokenPoolAdvancedPoolHook.ts`**, **`LockAndReleaseTokenPool.ts`:** Deploy **CrossChainToken** (constructor tuple + deployer as admin roles) and call **`registerAdminViaGetCCIPAdmin`**.
- **Return value rename:** deploy artifacts expose **`crossChainToken`** instead of **`factoryBurnMintERC20`**.

### Tasks & scripts

- **`scripts/CallEncodeExtraArgsOffchain.ts`:** **`encodeV3Basic`** calls the Solidity **`encodeV3Basic`** (gas + block confirmations).
- **Task:** **`executor-min-block-confirmations`** → **`executor-allowed-finality-config`**; helper **`ExecutorAllowedFinalityConfig.ts`** reads **`getAllowedFinalityConfig()`** (`bytes4`).

### Docs (`book/`)

- Examples **01, 02, 06, 07, 08** and **`ccip-sdk-ccip-send`:** CrossChainToken, **`registerAdminViaGetCCIPAdmin`**, **`getCCVsAndFinalityConfig`**, and executor **allowed finality** / FinalityCodec wording.