### PR TITLE
fix: add MockRouter import to generate missing artifact for test suite

### DIFF
--- a/contracts/test/MockRouterImport.sol
+++ b/contracts/test/MockRouterImport.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+// Forces Hardhat to compile MockCCIPRouter artifact required by test suite.
+// Hardhat does not compile contracts inside node_modules by default,
+// so without this import the artifact is never generated and tests fail
+// with HH700: Artifact for contract MockCCIPRouter not found.
+import "@chainlink/contracts-ccip/contracts/test/mocks/MockRouter.sol";


### PR DESCRIPTION
## Problem

Running `npx hardhat test` out of the box fails with the following error after a clean clone:
HardhatError: HH700: Artifact for contract
"@chainlink/contracts-ccip/contracts/test/mocks/MockRouter.sol:MockCCIPRouter" not found.

## Root Cause
Hardhat does not compile contracts inside `node_modules` by default. `MockCCIPRouter` is referenced in `Example1.spec.ts` but lives inside `@chainlink/contracts-ccip` — so its artifact is never generated unless there is an explicit import somewhere in the project source tree.

## Fix

Added a minimal import file under `contracts/test/MockRouterImport.sol` that forces Hardhat to include `MockRouter.sol` in the compilation step and generate the required artifact.

## Steps to Reproduce

```bash
git clone https://github.com/smartcontractkit/ccip-starter-kit-hardhat
cd ccip-starter-kit-hardhat
npm install
npx hardhat test test/no-fork/Example1.spec.ts
# → HH700 error
```

## Steps to Verify Fix

```bash
npx hardhat compile
npx hardhat test test/no-fork/Example1.spec.ts
# → 1 passing
```

## Environment

- `@chainlink/contracts-ccip`: 1.6.2  
- `@chainlink/local`: 0.2.7-beta.0  
- `hardhat`: 2.22.x  
- Node: 20.x  
- OS: macOS
